### PR TITLE
Silence warnings on MSVC

### DIFF
--- a/src/MVAnalyse.cpp
+++ b/src/MVAnalyse.cpp
@@ -68,15 +68,15 @@ typedef struct {
     int search;
     int search_coarse;
     int searchparam;
-    int isb;
-    int chroma;
+    bool isb;
+    bool chroma;
     int delta;
-    int truemotion;
+    bool truemotion;
     int overlap;
     int overlapv;
 
-    int fields;
-    int tff;
+    bool fields;
+    bool tff;
     int tffexists;
 } MVAnalyseData;
 
@@ -143,7 +143,7 @@ static const VSFrameRef *VS_CC mvanalyseGetFrame(int n, int activationReason, vo
         const VSMap *srcprops = vsapi->getFramePropsRO(src);
         int err;
 
-        bool srctff = vsapi->propGetInt(srcprops, "_Field", 0, &err);
+        bool srctff = !!vsapi->propGetInt(srcprops, "_Field", 0, &err);
         if (err && d->fields && !d->tffexists) {
             vsapi->setFilterError("Analyse: _Field property not found in input frame. Therefore, you must pass tff argument.", frameCtx);
             delete vectorFields;
@@ -185,7 +185,7 @@ static const VSFrameRef *VS_CC mvanalyseGetFrame(int n, int activationReason, vo
             const VSFrameRef *ref = vsapi->getFrameFilter(nref, d->node, frameCtx);
             const VSMap *refprops = vsapi->getFramePropsRO(ref);
 
-            bool reftff = vsapi->propGetInt(refprops, "_Field", 0, &err);
+            bool reftff = !!vsapi->propGetInt(refprops, "_Field", 0, &err);
             if (err && d->fields && !d->tffexists) {
                 vsapi->setFilterError("Analyse: _Field property not found in input frame. Therefore, you must pass tff argument.", frameCtx);
                 delete vectorFields;
@@ -278,101 +278,101 @@ static void VS_CC mvanalyseCreate(const VSMap *in, VSMap *out, void *userData, V
 
     int err;
 
-    d.blksize = vsapi->propGetInt(in, "blksize", 0, &err);
+    d.blksize = int64ToIntS(vsapi->propGetInt(in, "blksize", 0, &err));
     if (err)
         d.blksize = 8;
 
-    d.blksizev = vsapi->propGetInt(in, "blksizev", 0, &err);
+    d.blksizev = int64ToIntS(vsapi->propGetInt(in, "blksizev", 0, &err));
     if (err)
         d.blksizev = d.blksize;
 
-    d.levels = vsapi->propGetInt(in, "levels", 0, &err);
+    d.levels = int64ToIntS(vsapi->propGetInt(in, "levels", 0, &err));
 
-    d.search = vsapi->propGetInt(in, "search", 0, &err);
+    d.search = int64ToIntS(vsapi->propGetInt(in, "search", 0, &err));
     if (err)
         d.search = 4;
 
-    d.search_coarse = vsapi->propGetInt(in, "search_coarse", 0, &err);
+    d.search_coarse = int64ToIntS(vsapi->propGetInt(in, "search_coarse", 0, &err));
     if (err)
         d.search_coarse = 3;
 
-    d.searchparam = vsapi->propGetInt(in, "searchparam", 0, &err);
+    d.searchparam = int64ToIntS(vsapi->propGetInt(in, "searchparam", 0, &err));
     if (err)
         d.searchparam = 2;
 
-    d.nPelSearch = vsapi->propGetInt(in, "pelsearch", 0, &err);
+    d.nPelSearch = int64ToIntS(vsapi->propGetInt(in, "pelsearch", 0, &err));
 
-    d.isb = vsapi->propGetInt(in, "isb", 0, &err);
+    d.isb = !!vsapi->propGetInt(in, "isb", 0, &err);
 
-    d.chroma = vsapi->propGetInt(in, "chroma", 0, &err);
+    d.chroma = !!vsapi->propGetInt(in, "chroma", 0, &err);
     if (err)
         d.chroma = 1;
 
-    d.delta = vsapi->propGetInt(in, "delta", 0, &err);
+    d.delta = int64ToIntS(vsapi->propGetInt(in, "delta", 0, &err));
     if (err)
         d.delta = 1;
 
-    d.truemotion = vsapi->propGetInt(in, "truemotion", 0, &err);
+    d.truemotion = !!vsapi->propGetInt(in, "truemotion", 0, &err);
     if (err)
         d.truemotion = 1;
 
-    d.nLambda = vsapi->propGetInt(in, "lambda", 0, &err);
+    d.nLambda = int64ToIntS(vsapi->propGetInt(in, "lambda", 0, &err));
     if (err)
         d.nLambda = d.truemotion ? (1000 * d.blksize * d.blksizev / 64) : 0;
 
-    d.lsad = vsapi->propGetInt(in, "lsad", 0, &err);
+    d.lsad = int64ToIntS(vsapi->propGetInt(in, "lsad", 0, &err));
     if (err)
         d.lsad = d.truemotion ? 1200 : 400;
 
-    d.plevel = vsapi->propGetInt(in, "plevel", 0, &err);
+    d.plevel = int64ToIntS(vsapi->propGetInt(in, "plevel", 0, &err));
     if (err)
         d.plevel = d.truemotion ? 1 : 0;
 
-    d.global = vsapi->propGetInt(in, "global", 0, &err);
+    d.global = !!vsapi->propGetInt(in, "global", 0, &err);
     if (err)
         d.global = d.truemotion ? 1 : 0;
 
-    d.pnew = vsapi->propGetInt(in, "pnew", 0, &err);
+    d.pnew = int64ToIntS(vsapi->propGetInt(in, "pnew", 0, &err));
     if (err)
         d.pnew = d.truemotion ? 50 : 0; // relative to 256
 
-    d.pzero = vsapi->propGetInt(in, "pzero", 0, &err);
+    d.pzero = int64ToIntS(vsapi->propGetInt(in, "pzero", 0, &err));
     if (err)
         d.pzero = d.pnew;
 
-    d.pglobal = vsapi->propGetInt(in, "pglobal", 0, &err);
+    d.pglobal = int64ToIntS(vsapi->propGetInt(in, "pglobal", 0, &err));
 
-    d.overlap = vsapi->propGetInt(in, "overlap", 0, &err);
+    d.overlap = int64ToIntS(vsapi->propGetInt(in, "overlap", 0, &err));
 
-    d.overlapv = vsapi->propGetInt(in, "overlapv", 0, &err);
+    d.overlapv = int64ToIntS(vsapi->propGetInt(in, "overlapv", 0, &err));
     if (err)
         d.overlapv = d.overlap;
 
-    d.dctmode = vsapi->propGetInt(in, "dct", 0, &err);
+    d.dctmode = int64ToIntS(vsapi->propGetInt(in, "dct", 0, &err));
 
-    d.divideExtra = vsapi->propGetInt(in, "divide", 0, &err);
+    d.divideExtra = int64ToIntS(vsapi->propGetInt(in, "divide", 0, &err));
 
-    d.badSAD = vsapi->propGetInt(in, "badsad", 0, &err);
+    d.badSAD = int64ToIntS(vsapi->propGetInt(in, "badsad", 0, &err));
     if (err)
         d.badSAD = 10000;
 
-    d.badrange = vsapi->propGetInt(in, "badrange", 0, &err);
+    d.badrange = int64ToIntS(vsapi->propGetInt(in, "badrange", 0, &err));
     if (err)
         d.badrange = 24;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
-    d.meander = vsapi->propGetInt(in, "meander", 0, &err);
+    d.meander = !!vsapi->propGetInt(in, "meander", 0, &err);
     if (err)
         d.meander = 1;
 
-    d.tryMany = vsapi->propGetInt(in, "trymany", 0, &err);
+    d.tryMany = !!vsapi->propGetInt(in, "trymany", 0, &err);
 
     d.fields = !!vsapi->propGetInt(in, "fields", 0, &err);
 
-    d.tff = vsapi->propGetInt(in, "tff", 0, &err);
+    d.tff = !!vsapi->propGetInt(in, "tff", 0, &err);
     d.tffexists = err;
 
 
@@ -480,8 +480,8 @@ static void VS_CC mvanalyseCreate(const VSMap *in, VSMap *out, void *userData, V
     d.analysisData.bitsPerSample = d.vi.format->bitsPerSample;
 
     int pixelMax = (1 << d.vi.format->bitsPerSample) - 1;
-    d.lsad = (double)d.lsad * pixelMax / 255 + 0.5;
-    d.badSAD = (double)d.badSAD * pixelMax / 255 + 0.5;
+    d.lsad = int((double)d.lsad * pixelMax / 255.0 + 0.5);
+    d.badSAD = int((double)d.badSAD * pixelMax / 255.0 + 0.5);
 
     d.lsad = d.lsad * (d.blksize * d.blksizev) / 64;
     d.badSAD = d.badSAD * (d.blksize * d.blksizev) / 64;
@@ -534,12 +534,12 @@ static void VS_CC mvanalyseCreate(const VSMap *in, VSMap *out, void *userData, V
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[6];
-    int nHeight = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
-    d.nSuperVPad = vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]);
-    d.nSuperPel = vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]);
-    d.nSuperModeYUV = vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]);
-    d.nSuperLevels = vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]);
+    int nHeight = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
+    d.nSuperVPad = int64ToIntS(vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]));
+    d.nSuperPel = int64ToIntS(vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]));
+    d.nSuperModeYUV = int64ToIntS(vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]));
+    d.nSuperLevels = int64ToIntS(vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 6; i++)

--- a/src/MVBlockFPS.cpp
+++ b/src/MVBlockFPS.cpp
@@ -44,9 +44,9 @@ typedef struct {
     int64_t num, den;
     int mode;
     int thres;
-    int blend;
+    bool blend;
     int thscd1, thscd2;
-    int isse;
+    bool isse;
 
     MVClipDicks *mvClipB;
     MVClipDicks *mvClipF;
@@ -366,8 +366,8 @@ static const VSFrameRef *VS_CC mvblockfpsGetFrame(int n, int activationReason, v
         const int nHeightPUV = d->nHeightPUV;
         const int mode = d->mode;
         const int thres = d->thres;
-        const int blend = d->blend;
-        const int isse = d->isse;
+        const bool blend = d->blend;
+        const bool isse = d->isse;
         const int xRatioUV = d->bleh->xRatioUV;
         const int yRatioUV = d->bleh->yRatioUV;
         const int nBlkX = d->bleh->nBlkX;
@@ -767,24 +767,24 @@ static void VS_CC mvblockfpsCreate(const VSMap *in, VSMap *out, void *userData, 
     if (err)
         d.den = 1;
 
-    d.mode = vsapi->propGetInt(in, "mode", 0, &err);
+    d.mode = int64ToIntS(vsapi->propGetInt(in, "mode", 0, &err));
 
-    d.thres = vsapi->propGetInt(in, "thres", 0, &thres_err);
+    d.thres = int64ToIntS(vsapi->propGetInt(in, "thres", 0, &thres_err));
     // The default value is computed later.
 
     d.blend = !!vsapi->propGetInt(in, "blend", 0, &err);
     if (err)
         d.blend = 1;
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
@@ -806,12 +806,12 @@ static void VS_CC mvblockfpsCreate(const VSMap *in, VSMap *out, void *userData, 
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[6];
-    int nHeightS = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
-    d.nSuperVPad = vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]);
-    d.nSuperPel = vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]);
-    d.nSuperModeYUV = vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]);
-    d.nSuperLevels = vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]);
+    int nHeightS = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
+    d.nSuperVPad = int64ToIntS(vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]));
+    d.nSuperPel = int64ToIntS(vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]));
+    d.nSuperModeYUV = int64ToIntS(vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]));
+    d.nSuperLevels = int64ToIntS(vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 6; i++)

--- a/src/MVClip.cpp
+++ b/src/MVClip.cpp
@@ -73,7 +73,7 @@ MVClipDicks::MVClipDicks(VSNodeRef *vectors, int _nSCD1, int _nSCD2, const VSAPI
         nSCD1 += nSCD1 / (xRatioUV * yRatioUV) * 2;
 
     int pixelMax = (1 << bitsPerSample) - 1;
-    nSCD1 = (double)nSCD1 * pixelMax / 255 + 0.5;
+    nSCD1 = int((double)nSCD1 * pixelMax / 255.0 + 0.5);
 
     nSCD2 = _nSCD2 * nBlkCount / 256;
 

--- a/src/MVCompensate.cpp
+++ b/src/MVCompensate.cpp
@@ -40,8 +40,8 @@ typedef struct {
     bool fields;
     int nSCD1;
     int nSCD2;
-    int isse;
-    int tff;
+    bool isse;
+    bool tff;
     int tffexists;
 
     MVClipDicks *mvClip;
@@ -143,7 +143,7 @@ static const VSFrameRef *VS_CC mvcompensateGetFrame(int n, int activationReason,
         const int nBlkSizeY = d->bleh->nBlkSizeY;
         const int nBlkX = d->bleh->nBlkX;
         const int nBlkY = d->bleh->nBlkY;
-        const int isse = d->isse;
+        const bool isse = d->isse;
         const int thSAD = d->thSAD;
         const int dstTempPitch = d->dstTempPitch;
         const int dstTempPitchUV = d->dstTempPitchUV;
@@ -203,7 +203,7 @@ static const VSFrameRef *VS_CC mvcompensateGetFrame(int n, int activationReason,
             {
                 int err;
                 const VSMap *props = vsapi->getFramePropsRO(src);
-                bool paritySrc = vsapi->propGetInt(props, "_Field", 0, &err); //child->GetParity(n);
+                bool paritySrc = !!vsapi->propGetInt(props, "_Field", 0, &err); //child->GetParity(n);
                 if (err && !d->tffexists) {
                     vsapi->setFilterError("Compensate: _Field property not found in input frame. Therefore, you must pass tff argument.", frameCtx);
                     delete pRefGOF;
@@ -215,7 +215,7 @@ static const VSFrameRef *VS_CC mvcompensateGetFrame(int n, int activationReason,
                 }
 
                 props = vsapi->getFramePropsRO(ref);
-                bool parityRef = vsapi->propGetInt(props, "_Field", 0, &err); //child->GetParity(nref);
+                bool parityRef = !!vsapi->propGetInt(props, "_Field", 0, &err); //child->GetParity(nref);
                 if (err && !d->tffexists) {
                     vsapi->setFilterError("Compensate: _Field property not found in input frame. Therefore, you must pass tff argument.", frameCtx);
                     delete pRefGOF;
@@ -620,25 +620,25 @@ static void VS_CC mvcompensateCreate(const VSMap *in, VSMap *out, void *userData
 
     int err;
 
-    d.scBehavior = vsapi->propGetInt(in, "scbehavior", 0, &err);
+    d.scBehavior = !!vsapi->propGetInt(in, "scbehavior", 0, &err);
     if (err)
         d.scBehavior = 1;
 
-    d.thSAD = vsapi->propGetInt(in, "thsad", 0, &err);
+    d.thSAD = int64ToIntS(vsapi->propGetInt(in, "thsad", 0, &err));
     if (err)
         d.thSAD = 10000;
 
-    d.fields = vsapi->propGetInt(in, "fields", 0, &err);
+    d.fields = !!vsapi->propGetInt(in, "fields", 0, &err);
 
-    d.nSCD1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.nSCD1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.nSCD1 = MV_DEFAULT_SCD1;
 
-    d.nSCD2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.nSCD2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.nSCD2 = MV_DEFAULT_SCD2;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
@@ -657,12 +657,12 @@ static void VS_CC mvcompensateCreate(const VSMap *in, VSMap *out, void *userData
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[6];
-    int nHeightS = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
-    d.nSuperVPad = vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]);
-    d.nSuperPel = vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]);
-    d.nSuperModeYUV = vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]);
-    d.nSuperLevels = vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]);
+    int nHeightS = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
+    d.nSuperVPad = int64ToIntS(vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]));
+    d.nSuperPel = int64ToIntS(vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]));
+    d.nSuperModeYUV = int64ToIntS(vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]));
+    d.nSuperLevels = int64ToIntS(vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 6; i++)

--- a/src/MVDegrains.h
+++ b/src/MVDegrains.h
@@ -173,7 +173,7 @@ static void LimitChanges_C(uint8_t *pDst8, intptr_t nDstPitch, const uint8_t *pS
             const PixelType *pSrc = (const PixelType *)pSrc8;
             PixelType *pDst = (PixelType *)pDst8;
 
-            pDst[i] = VSMIN( VSMAX(pDst[i], (pSrc[i] - nLimit)), (pSrc[i] + nLimit));
+            pDst[i] = (PixelType)VSMIN(VSMAX(pDst[i], (pSrc[i] - nLimit)), (pSrc[i] + nLimit));
         }
         pDst8 += nDstPitch;
         pSrc8 += nSrcPitch;
@@ -185,7 +185,7 @@ inline int DegrainWeight(int64_t thSAD, int64_t blockSAD) {
     if (blockSAD >= thSAD)
         return 0;
 
-    return (thSAD - blockSAD) * (thSAD + blockSAD) * 256 / (thSAD * thSAD + blockSAD * blockSAD);
+    return int((thSAD - blockSAD) * (thSAD + blockSAD) * 256 / (thSAD * thSAD + blockSAD * blockSAD));
 }
 
 

--- a/src/MVFinest.cpp
+++ b/src/MVFinest.cpp
@@ -171,7 +171,7 @@ static void VS_CC mvfinestCreate(const VSMap *in, VSMap *out, void *userData, VS
 
     int err;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
@@ -197,12 +197,12 @@ static void VS_CC mvfinestCreate(const VSMap *in, VSMap *out, void *userData, VS
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[6];
-    d.nHeight = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
-    d.nSuperVPad = vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]);
-    d.nSuperPel = vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]);
-    d.nSuperModeYUV = vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]);
-    d.nSuperLevels = vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]);
+    d.nHeight = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
+    d.nSuperVPad = int64ToIntS(vsapi->propGetInt(props, "Super vpad", 0, &evil_err[2]));
+    d.nSuperPel = int64ToIntS(vsapi->propGetInt(props, "Super pel", 0, &evil_err[3]));
+    d.nSuperModeYUV = int64ToIntS(vsapi->propGetInt(props, "Super modeyuv", 0, &evil_err[4]));
+    d.nSuperLevels = int64ToIntS(vsapi->propGetInt(props, "Super levels", 0, &evil_err[5]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 6; i++)

--- a/src/MVFlowBlur.cpp
+++ b/src/MVFlowBlur.cpp
@@ -44,7 +44,7 @@ typedef struct {
     int prec;
     int thscd1;
     int thscd2;
-    int isse;
+    bool isse;
 
     MVClipDicks *mvClipB;
     MVClipDicks *mvClipF;
@@ -456,23 +456,23 @@ static void VS_CC mvflowblurCreate(const VSMap *in, VSMap *out, void *userData, 
 
     int err;
 
-    d.blur = vsapi->propGetFloat(in, "blur", 0, &err);
+    d.blur = (float)vsapi->propGetFloat(in, "blur", 0, &err);
     if (err)
         d.blur = 50.0f;
 
-    d.prec = vsapi->propGetInt(in, "prec", 0, &err);
+    d.prec = int64ToIntS(vsapi->propGetInt(in, "prec", 0, &err));
     if (err)
         d.prec = 1;
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
@@ -501,8 +501,8 @@ static void VS_CC mvflowblurCreate(const VSMap *in, VSMap *out, void *userData, 
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[2];
-    int nHeightS = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
+    int nHeightS = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 2; i++)

--- a/src/MVFlowFPS.cpp
+++ b/src/MVFlowFPS.cpp
@@ -43,9 +43,9 @@ typedef struct {
     int64_t num, den;
     int maskmode;
     double ml;
-    int blend;
+    bool blend;
     int thscd1, thscd2;
-    int isse;
+    bool isse;
 
     MVClipDicks *mvClipB;
     MVClipDicks *mvClipF;
@@ -203,8 +203,8 @@ static const VSFrameRef *VS_CC mvflowfpsGetFrame(int n, int activationReason, vo
         const int nWidthUV = d->nWidthUV;
         const int nHeightUV = d->nHeightUV;
         const int maskmode = d->maskmode;
-        const int blend = d->blend;
-        const int isse = d->isse;
+        const bool blend = d->blend;
+        const bool isse = d->isse;
         const double ml = d->ml;
         const int xRatioUV = d->bleh->xRatioUV;
         const int yRatioUV = d->bleh->yRatioUV;
@@ -629,7 +629,7 @@ static void VS_CC mvflowfpsCreate(const VSMap *in, VSMap *out, void *userData, V
     if (err)
         d.den = 1;
 
-    d.maskmode = vsapi->propGetInt(in, "mask", 0, &err);
+    d.maskmode = int64ToIntS(vsapi->propGetInt(in, "mask", 0, &err));
     if (err)
         d.maskmode = 2;
 
@@ -641,15 +641,15 @@ static void VS_CC mvflowfpsCreate(const VSMap *in, VSMap *out, void *userData, V
     if (err)
         d.blend = 1;
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 
-    d.isse = vsapi->propGetInt(in, "isse", 0, &err);
+    d.isse = !!vsapi->propGetInt(in, "isse", 0, &err);
     if (err)
         d.isse = 1;
 
@@ -676,8 +676,8 @@ static void VS_CC mvflowfpsCreate(const VSMap *in, VSMap *out, void *userData, V
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[2];
-    int nHeightS = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
+    int nHeightS = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 2; i++)

--- a/src/MVFlowInter.cpp
+++ b/src/MVFlowInter.cpp
@@ -42,10 +42,10 @@ typedef struct {
 
     float time;
     float ml;
-    int blend;
+    bool blend;
     int thscd1;
     int thscd2;
-    int isse;
+    bool isse;
 
     MVClipDicks *mvClipB;
     MVClipDicks *mvClipF;
@@ -134,8 +134,8 @@ static const VSFrameRef *VS_CC mvflowinterGetFrame(int n, int activationReason, 
         const int nWidthUV = d->nWidthUV;
         const int nHeightUV = d->nHeightUV;
         const int time256 = d->time256;
-        const int blend = d->blend;
-        const int isse = d->isse;
+        const bool blend = d->blend;
+        const bool isse = d->isse;
 
         int bitsPerSample = d->vi->format->bitsPerSample;
         int bytesPerSample = d->vi->format->bytesPerSample;
@@ -525,11 +525,11 @@ static void VS_CC mvflowinterCreate(const VSMap *in, VSMap *out, void *userData,
     if (err)
         d.blend = 1;
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 
@@ -562,8 +562,8 @@ static void VS_CC mvflowinterCreate(const VSMap *in, VSMap *out, void *userData,
     }
     const VSMap *props = vsapi->getFramePropsRO(evil);
     int evil_err[2];
-    int nHeightS = vsapi->propGetInt(props, "Super height", 0, &evil_err[0]);
-    d.nSuperHPad = vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]);
+    int nHeightS = int64ToIntS(vsapi->propGetInt(props, "Super height", 0, &evil_err[0]));
+    d.nSuperHPad = int64ToIntS(vsapi->propGetInt(props, "Super hpad", 0, &evil_err[1]));
     vsapi->freeFrame(evil);
 
     for (int i = 0; i < 2; i++)

--- a/src/MVInterface.h
+++ b/src/MVInterface.h
@@ -154,7 +154,7 @@ class MVAnalysisData
         inline int GetDeltaFrame() const { return nDeltaFrame; }
         inline int GetWidth() const { return nWidth; }
         inline int GetHeight() const { return nHeight; }
-        inline bool IsChromaMotion() const { return nMotionFlags & MOTION_USE_CHROMA_MOTION; }
+        inline bool IsChromaMotion() const { return !!(nMotionFlags & MOTION_USE_CHROMA_MOTION); }
         inline int GetOverlapX() const { return nOverlapX; }
         inline int GetBlkX() const { return nBlkX; }
         inline int GetBlkY() const { return nBlkY; }

--- a/src/MVMask.cpp
+++ b/src/MVMask.cpp
@@ -34,7 +34,7 @@ typedef struct {
     VSVideoInfo vi;
 
     VSNodeRef *vectors;
-    int ml;
+    float ml;
     float fGamma;
     int kind;
     int nSceneChangeValue;
@@ -249,23 +249,23 @@ static void VS_CC mvmaskCreate(const VSMap *in, VSMap *out, void *userData, VSCo
 
     int err;
 
-    d.ml = vsapi->propGetFloat(in, "ml", 0, &err);
+    d.ml = (float)vsapi->propGetFloat(in, "ml", 0, &err);
     if (err)
-        d.ml = 100.0;
+        d.ml = 100.0f;
 
     d.fGamma = (float)vsapi->propGetFloat(in, "gamma", 0, &err);
     if (err)
         d.fGamma = 1.0f;
 
-    d.kind = vsapi->propGetInt(in, "kind", 0, &err);
+    d.kind = int64ToIntS(vsapi->propGetInt(in, "kind", 0, &err));
 
-    d.nSceneChangeValue = vsapi->propGetInt(in, "ysc", 0, &err);
+    d.nSceneChangeValue = int64ToIntS(vsapi->propGetInt(in, "ysc", 0, &err));
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 

--- a/src/MVSCDetection.cpp
+++ b/src/MVSCDetection.cpp
@@ -89,11 +89,11 @@ static void VS_CC mvscdetectionCreate(const VSMap *in, VSMap *out, void *userDat
 
     int err;
 
-    d.thscd1 = vsapi->propGetInt(in, "thscd1", 0, &err);
+    d.thscd1 = int64ToIntS(vsapi->propGetInt(in, "thscd1", 0, &err));
     if (err)
         d.thscd1 = MV_DEFAULT_SCD1;
 
-    d.thscd2 = vsapi->propGetInt(in, "thscd2", 0, &err);
+    d.thscd2 = int64ToIntS(vsapi->propGetInt(in, "thscd2", 0, &err));
     if (err)
         d.thscd2 = MV_DEFAULT_SCD2;
 

--- a/src/MVSuper.cpp
+++ b/src/MVSuper.cpp
@@ -144,29 +144,29 @@ static void VS_CC mvsuperCreate(const VSMap *in, VSMap *out, void *userData, VSC
 
     int err;
 
-    d.nHPad = vsapi->propGetInt(in, "hpad", 0, &err);
+    d.nHPad = int64ToIntS(vsapi->propGetInt(in, "hpad", 0, &err));
     if (err)
         d.nHPad = 8;
 
-    d.nVPad = vsapi->propGetInt(in, "vpad", 0, &err);
+    d.nVPad = int64ToIntS(vsapi->propGetInt(in, "vpad", 0, &err));
     if (err)
         d.nVPad = 8;
 
-    d.nPel = vsapi->propGetInt(in, "pel", 0, &err);
+    d.nPel = int64ToIntS(vsapi->propGetInt(in, "pel", 0, &err));
     if (err)
         d.nPel = 2;
 
-    d.nLevels = vsapi->propGetInt(in, "levels", 0, &err);
+    d.nLevels = int64ToIntS(vsapi->propGetInt(in, "levels", 0, &err));
 
     d.chroma = !!vsapi->propGetInt(in, "chroma", 0, &err);
     if (err)
         d.chroma = 1;
 
-    d.sharp = vsapi->propGetInt(in, "sharp", 0, &err); // pel2 interpolation type
+    d.sharp = int64ToIntS(vsapi->propGetInt(in, "sharp", 0, &err)); // pel2 interpolation type
     if (err)
         d.sharp = 2;
 
-    d.rfilter = vsapi->propGetInt(in, "rfilter", 0, &err);
+    d.rfilter = int64ToIntS(vsapi->propGetInt(in, "rfilter", 0, &err));
     if (err)
         d.rfilter = 2;
 

--- a/src/MaskFun.cpp
+++ b/src/MaskFun.cpp
@@ -573,8 +573,8 @@ void RealFlowInter(uint8_t * pdst8, int dst_pitch, const uint8_t *prefB8, const 
                 int vyB = LUTVB[VYFullB[w]];
                 int64_t dstB = prefB[vyB*ref_pitch + vxB + w];
                 int dstB0 = prefB[w]; // zero
-                pdst[w] = ( ( (dstF*(255-MaskF[w]) + ((MaskF[w]*(dstB*(255-MaskB[w])+MaskB[w]*dstF0)+255)>>8) + 255)>>8 )*(256-time256) +
-                        ( (dstB*(255-MaskB[w]) + ((MaskB[w]*(dstF*(255-MaskF[w])+MaskF[w]*dstB0)+255)>>8) + 255)>>8 )*time256 )>>8;
+                pdst[w] = PixelType((((dstF*(255 - MaskF[w]) + ((MaskF[w] * (dstB*(255 - MaskB[w]) + MaskB[w] * dstF0) + 255) >> 8) + 255) >> 8)*(256 - time256) +
+                    ((dstB*(255 - MaskB[w]) + ((MaskB[w] * (dstF*(255 - MaskF[w]) + MaskF[w] * dstB0) + 255) >> 8) + 255) >> 8)*time256) >> 8);
             }
             pdst += dst_pitch;
             prefB += ref_pitch;

--- a/src/PlaneOfBlocks.cpp
+++ b/src/PlaneOfBlocks.cpp
@@ -54,17 +54,17 @@ PlaneOfBlocks::PlaneOfBlocks(int _nBlkX, int _nBlkY, int _nBlkSizeX, int _nBlkSi
     bitsPerSample = _bitsPerSample;
     bytesPerSample = (bitsPerSample + 7) / 8;
 
-    smallestPlane = (bool)(nMotionFlags & MOTION_SMALLEST_PLANE);
-    isse = (bool)(nMotionFlags & MOTION_USE_ISSE);
-    chroma = (bool)(nMotionFlags & MOTION_USE_CHROMA_MOTION);
+    smallestPlane = !!(nMotionFlags & MOTION_SMALLEST_PLANE);
+    isse = !!(nMotionFlags & MOTION_USE_ISSE);
+    chroma = !!(nMotionFlags & MOTION_USE_CHROMA_MOTION);
 
-    bool cache64 = (bool)(nCPUFlags & X264_CPU_CACHELINE_64);
-    bool sse3 = (bool)(nCPUFlags & X264_CPU_SSE3);
-    bool ssse3 = (bool)(nCPUFlags & X264_CPU_SSSE3);
-    bool sse41 = (bool)(nCPUFlags & X264_CPU_SSE4);
-    bool avx = (bool)(nCPUFlags & X264_CPU_AVX);
-    bool xop = (bool)(nCPUFlags & X264_CPU_XOP);
-    bool avx2 = (bool)(nCPUFlags & X264_CPU_AVX2);
+    bool cache64 = !!(nCPUFlags & X264_CPU_CACHELINE_64);
+    bool sse3 = !!(nCPUFlags & X264_CPU_SSE3);
+    bool ssse3 = !!(nCPUFlags & X264_CPU_SSSE3);
+    bool sse41 = !!(nCPUFlags & X264_CPU_SSE4);
+    bool avx = !!(nCPUFlags & X264_CPU_AVX);
+    bool xop = !!(nCPUFlags & X264_CPU_XOP);
+    bool avx2 = !!(nCPUFlags & X264_CPU_AVX2);
 
     globalMVPredictor.x = zeroMV.x;
     globalMVPredictor.y = zeroMV.y;

--- a/src/SADFunctions.h
+++ b/src/SADFunctions.h
@@ -102,7 +102,7 @@ unsigned int Real_Satd_4x4_C(const uint8_t *pSrc8, intptr_t nSrcPitch, const uin
         sum += ((SumType)a0) + (a0 >> bitsPerSum);
     }
 
-    return sum >> 1;
+    return (unsigned int)(sum >> 1);
 }
 
 
@@ -141,7 +141,7 @@ unsigned int Real_Satd_8x4_C(const uint8_t *pSrc8, intptr_t nSrcPitch, const uin
         sum += abs2<SumType, SumType2>(a0) + abs2<SumType, SumType2>(a1) + abs2<SumType, SumType2>(a2) + abs2<SumType, SumType2>(a3);
     }
 
-    return (((SumType)sum) + (sum >> bitsPerSum)) >> 1;
+    return (unsigned int)((((SumType)sum) + (sum >> bitsPerSum)) >> 1);
 }
 
 


### PR DESCRIPTION
Also fix a typo that the variable ml in MVMaskData is incorrectly decalred as type int, which should be float.