### PR TITLE
typo in meson.build #42

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,7 @@ sources = [
   'src/MVSCDetection.c',
   'src/MVSuper.c',
   'src/Overlap.cpp',
-  'src/PlaneOfBlocks.c',
+  'src/PlaneOfBlocks.cpp',
   'src/SADFunctions.cpp',
   'src/SimpleResize.cpp',
 ]


### PR DESCRIPTION
"PlaneOfBlocks.c" > "PlaneOfBlocks.cpp"