### PR TITLE
Add MDegrain4-6 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ltmain.sh
 missing
 .deps/
 .dirstamp
+.cache/

--- a/src/MVDegrains.cpp
+++ b/src/MVDegrains.cpp
@@ -38,7 +38,7 @@ struct MVDegrainData {
     const VSVideoInfo *vi;
 
     VSNodeRef *super;
-    VSNodeRef *vectors[6];
+    VSNodeRef *vectors[12];
 
     int64_t thSAD[3];
     int YUVplanes;
@@ -47,7 +47,7 @@ struct MVDegrainData {
     int nSCD2;
     int opt;
 
-    MVAnalysisData vectors_data[6];
+    MVAnalysisData vectors_data[12];
 
     int nSuperHPad;
     int nSuperVPad;
@@ -96,6 +96,13 @@ static const VSFrameRef *VS_CC mvdegrainGetFrame(int n, int activationReason, vo
     MVDegrainData *d = (MVDegrainData *)*instanceData;
 
     if (activationReason == arInitial) {
+        //TODO: Clean this up to just use a loop.
+        if (radius > 5)
+            vsapi->requestFrameFilter(n, d->vectors[Forward6], frameCtx);
+        if (radius > 4)
+            vsapi->requestFrameFilter(n, d->vectors[Forward5], frameCtx);
+        if (radius > 3)
+            vsapi->requestFrameFilter(n, d->vectors[Forward4], frameCtx);
         if (radius > 2)
             vsapi->requestFrameFilter(n, d->vectors[Forward3], frameCtx);
         if (radius > 1)
@@ -106,6 +113,30 @@ static const VSFrameRef *VS_CC mvdegrainGetFrame(int n, int activationReason, vo
             vsapi->requestFrameFilter(n, d->vectors[Backward2], frameCtx);
         if (radius > 2)
             vsapi->requestFrameFilter(n, d->vectors[Backward3], frameCtx);
+        if (radius > 3)
+            vsapi->requestFrameFilter(n, d->vectors[Backward4], frameCtx);
+        if (radius > 4)
+            vsapi->requestFrameFilter(n, d->vectors[Backward5], frameCtx);
+        if (radius > 5)
+            vsapi->requestFrameFilter(n, d->vectors[Backward6], frameCtx);
+
+        if (radius > 5) {
+            int offF6 = -1 * d->vectors_data[Forward6].nDeltaFrame;
+            if (n + offF6 >= 0)
+                vsapi->requestFrameFilter(n + offF6, d->super, frameCtx);
+        }
+
+        if (radius > 4) {
+            int offF5 = -1 * d->vectors_data[Forward5].nDeltaFrame;
+            if (n + offF5 >= 0)
+                vsapi->requestFrameFilter(n + offF5, d->super, frameCtx);
+        }
+
+        if (radius > 3) {
+            int offF4 = -1 * d->vectors_data[Forward4].nDeltaFrame;
+            if (n + offF4 >= 0)
+                vsapi->requestFrameFilter(n + offF4, d->super, frameCtx);
+        }
 
         if (radius > 2) {
             int offF3 = -1 * d->vectors_data[Forward3].nDeltaFrame;
@@ -137,6 +168,24 @@ static const VSFrameRef *VS_CC mvdegrainGetFrame(int n, int activationReason, vo
             int offB3 = d->vectors_data[Backward3].nDeltaFrame;
             if (n + offB3 < d->vi->numFrames)
                 vsapi->requestFrameFilter(n + offB3, d->super, frameCtx);
+        }
+
+        if (radius > 3) {
+            int offB4 = d->vectors_data[Backward4].nDeltaFrame;
+            if (n + offB4 < d->vi->numFrames)
+                vsapi->requestFrameFilter(n + offB4, d->super, frameCtx);
+        }
+
+        if (radius > 4) {
+            int offB5 = d->vectors_data[Backward5].nDeltaFrame;
+            if (n + offB5 < d->vi->numFrames)
+                vsapi->requestFrameFilter(n + offB5, d->super, frameCtx);
+        }
+
+        if (radius > 5) {
+            int offB6 = d->vectors_data[Backward6].nDeltaFrame;
+            if (n + offB6 < d->vi->numFrames)
+                vsapi->requestFrameFilter(n + offB6, d->super, frameCtx);
         }
 
         vsapi->requestFrameFilter(n, d->node, frameCtx);
@@ -393,186 +442,91 @@ static void VS_CC mvdegrainFree(void *instanceData, VSCore *core, const VSAPI *v
 #if defined(MVTOOLS_X86)
 #define DEGRAIN_SSE2(radius, width, height) \
     { KEY(width, height, 8, MVOPT_SSE2), Degrain_sse2<radius, width, height> },
+
+#define DEGRAIN_LEVEL_SSE2(radius)\
+    {\
+        DEGRAIN_SSE2(radius, 4, 2)\
+        DEGRAIN_SSE2(radius, 4, 4)\
+        DEGRAIN_SSE2(radius, 4, 8)\
+        DEGRAIN_SSE2(radius, 8, 1)\
+        DEGRAIN_SSE2(radius, 8, 2)\
+        DEGRAIN_SSE2(radius, 8, 4)\
+        DEGRAIN_SSE2(radius, 8, 8)\
+        DEGRAIN_SSE2(radius, 8, 16)\
+        DEGRAIN_SSE2(radius, 16, 1)\
+        DEGRAIN_SSE2(radius, 16, 2)\
+        DEGRAIN_SSE2(radius, 16, 4)\
+        DEGRAIN_SSE2(radius, 16, 8)\
+        DEGRAIN_SSE2(radius, 16, 16)\
+        DEGRAIN_SSE2(radius, 16, 32)\
+        DEGRAIN_SSE2(radius, 32, 8)\
+        DEGRAIN_SSE2(radius, 32, 16)\
+        DEGRAIN_SSE2(radius, 32, 32)\
+        DEGRAIN_SSE2(radius, 32, 64)\
+        DEGRAIN_SSE2(radius, 64, 16)\
+        DEGRAIN_SSE2(radius, 64, 32)\
+        DEGRAIN_SSE2(radius, 64, 64)\
+        DEGRAIN_SSE2(radius, 64, 128)\
+        DEGRAIN_SSE2(radius, 128, 32)\
+        DEGRAIN_SSE2(radius, 128, 64)\
+        DEGRAIN_SSE2(radius, 128, 128)\
+    }
 #else
 #define DEGRAIN_SSE2(radius, width, height)
+#define DEGRAIN_LEVEL_SSE2(radius)
 #endif
 
 #define DEGRAIN(radius, width, height) \
     { KEY(width, height, 8, MVOPT_SCALAR), Degrain_C<radius, width, height, uint8_t> }, \
     { KEY(width, height, 16, MVOPT_SCALAR), Degrain_C<radius, width, height, uint16_t> },
 
-static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions[3] = {
-    {
-        DEGRAIN(1, 2, 2)
-        DEGRAIN(1, 2, 4)
-        DEGRAIN(1, 4, 2)
-        DEGRAIN(1, 4, 4)
-        DEGRAIN(1, 4, 8)
-        DEGRAIN(1, 8, 1)
-        DEGRAIN(1, 8, 2)
-        DEGRAIN(1, 8, 4)
-        DEGRAIN(1, 8, 8)
-        DEGRAIN(1, 8, 16)
-        DEGRAIN(1, 16, 1)
-        DEGRAIN(1, 16, 2)
-        DEGRAIN(1, 16, 4)
-        DEGRAIN(1, 16, 8)
-        DEGRAIN(1, 16, 16)
-        DEGRAIN(1, 16, 32)
-        DEGRAIN(1, 32, 8)
-        DEGRAIN(1, 32, 16)
-        DEGRAIN(1, 32, 32)
-        DEGRAIN(1, 32, 64)
-        DEGRAIN(1, 64, 16)
-        DEGRAIN(1, 64, 32)
-        DEGRAIN(1, 64, 64)
-        DEGRAIN(1, 64, 128)
-        DEGRAIN(1, 128, 32)
-        DEGRAIN(1, 128, 64)
-        DEGRAIN(1, 128, 128)
-    },
-    {
-        DEGRAIN(2, 2, 2)
-        DEGRAIN(2, 2, 4)
-        DEGRAIN(2, 4, 2)
-        DEGRAIN(2, 4, 4)
-        DEGRAIN(2, 4, 8)
-        DEGRAIN(2, 8, 1)
-        DEGRAIN(2, 8, 2)
-        DEGRAIN(2, 8, 4)
-        DEGRAIN(2, 8, 8)
-        DEGRAIN(2, 8, 16)
-        DEGRAIN(2, 16, 1)
-        DEGRAIN(2, 16, 2)
-        DEGRAIN(2, 16, 4)
-        DEGRAIN(2, 16, 8)
-        DEGRAIN(2, 16, 16)
-        DEGRAIN(2, 16, 32)
-        DEGRAIN(2, 32, 8)
-        DEGRAIN(2, 32, 16)
-        DEGRAIN(2, 32, 32)
-        DEGRAIN(2, 32, 64)
-        DEGRAIN(2, 64, 16)
-        DEGRAIN(2, 64, 32)
-        DEGRAIN(2, 64, 64)
-        DEGRAIN(2, 64, 128)
-        DEGRAIN(2, 128, 32)
-        DEGRAIN(2, 128, 64)
-        DEGRAIN(2, 128, 128)
-    },
-    {
-        DEGRAIN(3, 2, 2)
-        DEGRAIN(3, 2, 4)
-        DEGRAIN(3, 4, 2)
-        DEGRAIN(3, 4, 4)
-        DEGRAIN(3, 4, 8)
-        DEGRAIN(3, 8, 1)
-        DEGRAIN(3, 8, 2)
-        DEGRAIN(3, 8, 4)
-        DEGRAIN(3, 8, 8)
-        DEGRAIN(3, 8, 16)
-        DEGRAIN(3, 16, 1)
-        DEGRAIN(3, 16, 2)
-        DEGRAIN(3, 16, 4)
-        DEGRAIN(3, 16, 8)
-        DEGRAIN(3, 16, 16)
-        DEGRAIN(3, 16, 32)
-        DEGRAIN(3, 32, 8)
-        DEGRAIN(3, 32, 16)
-        DEGRAIN(3, 32, 32)
-        DEGRAIN(3, 32, 64)
-        DEGRAIN(3, 64, 16)
-        DEGRAIN(3, 64, 32)
-        DEGRAIN(3, 64, 64)
-        DEGRAIN(3, 64, 128)
-        DEGRAIN(3, 128, 32)
-        DEGRAIN(3, 128, 64)
-        DEGRAIN(3, 128, 128)
+#define DEGRAIN_LEVEL(radius)\
+    {\
+        DEGRAIN(radius, 2, 2)\
+        DEGRAIN(radius, 2, 4)\
+        DEGRAIN(radius, 4, 2)\
+        DEGRAIN(radius, 4, 4)\
+        DEGRAIN(radius, 4, 8)\
+        DEGRAIN(radius, 8, 1)\
+        DEGRAIN(radius, 8, 2)\
+        DEGRAIN(radius, 8, 4)\
+        DEGRAIN(radius, 8, 8)\
+        DEGRAIN(radius, 8, 16)\
+        DEGRAIN(radius, 16, 1)\
+        DEGRAIN(radius, 16, 2)\
+        DEGRAIN(radius, 16, 4)\
+        DEGRAIN(radius, 16, 8)\
+        DEGRAIN(radius, 16, 16)\
+        DEGRAIN(radius, 16, 32)\
+        DEGRAIN(radius, 32, 8)\
+        DEGRAIN(radius, 32, 16)\
+        DEGRAIN(radius, 32, 32)\
+        DEGRAIN(radius, 32, 64)\
+        DEGRAIN(radius, 64, 16)\
+        DEGRAIN(radius, 64, 32)\
+        DEGRAIN(radius, 64, 64)\
+        DEGRAIN(radius, 64, 128)\
+        DEGRAIN(radius, 128, 32)\
+        DEGRAIN(radius, 128, 64)\
+        DEGRAIN(radius, 128, 128)\
     }
+
+static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions[6] = {
+    DEGRAIN_LEVEL(1),
+    DEGRAIN_LEVEL(2),
+    DEGRAIN_LEVEL(3),
+    DEGRAIN_LEVEL(4),
+    DEGRAIN_LEVEL(5),
+    DEGRAIN_LEVEL(6),
 };
 
-static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions_sse2[3] = {
-    {
-        DEGRAIN_SSE2(1, 4, 2)
-        DEGRAIN_SSE2(1, 4, 4)
-        DEGRAIN_SSE2(1, 4, 8)
-        DEGRAIN_SSE2(1, 8, 1)
-        DEGRAIN_SSE2(1, 8, 2)
-        DEGRAIN_SSE2(1, 8, 4)
-        DEGRAIN_SSE2(1, 8, 8)
-        DEGRAIN_SSE2(1, 8, 16)
-        DEGRAIN_SSE2(1, 16, 1)
-        DEGRAIN_SSE2(1, 16, 2)
-        DEGRAIN_SSE2(1, 16, 4)
-        DEGRAIN_SSE2(1, 16, 8)
-        DEGRAIN_SSE2(1, 16, 16)
-        DEGRAIN_SSE2(1, 16, 32)
-        DEGRAIN_SSE2(1, 32, 8)
-        DEGRAIN_SSE2(1, 32, 16)
-        DEGRAIN_SSE2(1, 32, 32)
-        DEGRAIN_SSE2(1, 32, 64)
-        DEGRAIN_SSE2(1, 64, 16)
-        DEGRAIN_SSE2(1, 64, 32)
-        DEGRAIN_SSE2(1, 64, 64)
-        DEGRAIN_SSE2(1, 64, 128)
-        DEGRAIN_SSE2(1, 128, 32)
-        DEGRAIN_SSE2(1, 128, 64)
-        DEGRAIN_SSE2(1, 128, 128)
-    },
-    {
-        DEGRAIN_SSE2(2, 4, 2)
-        DEGRAIN_SSE2(2, 4, 4)
-        DEGRAIN_SSE2(2, 4, 8)
-        DEGRAIN_SSE2(2, 8, 1)
-        DEGRAIN_SSE2(2, 8, 2)
-        DEGRAIN_SSE2(2, 8, 4)
-        DEGRAIN_SSE2(2, 8, 8)
-        DEGRAIN_SSE2(2, 8, 16)
-        DEGRAIN_SSE2(2, 16, 1)
-        DEGRAIN_SSE2(2, 16, 2)
-        DEGRAIN_SSE2(2, 16, 4)
-        DEGRAIN_SSE2(2, 16, 8)
-        DEGRAIN_SSE2(2, 16, 16)
-        DEGRAIN_SSE2(2, 16, 32)
-        DEGRAIN_SSE2(2, 32, 8)
-        DEGRAIN_SSE2(2, 32, 16)
-        DEGRAIN_SSE2(2, 32, 32)
-        DEGRAIN_SSE2(2, 32, 64)
-        DEGRAIN_SSE2(2, 64, 16)
-        DEGRAIN_SSE2(2, 64, 32)
-        DEGRAIN_SSE2(2, 64, 64)
-        DEGRAIN_SSE2(2, 64, 128)
-        DEGRAIN_SSE2(2, 128, 32)
-        DEGRAIN_SSE2(2, 128, 64)
-        DEGRAIN_SSE2(2, 128, 128)
-    },
-    {
-        DEGRAIN_SSE2(3, 4, 2)
-        DEGRAIN_SSE2(3, 4, 4)
-        DEGRAIN_SSE2(3, 4, 8)
-        DEGRAIN_SSE2(3, 8, 1)
-        DEGRAIN_SSE2(3, 8, 2)
-        DEGRAIN_SSE2(3, 8, 4)
-        DEGRAIN_SSE2(3, 8, 8)
-        DEGRAIN_SSE2(3, 8, 16)
-        DEGRAIN_SSE2(3, 16, 1)
-        DEGRAIN_SSE2(3, 16, 2)
-        DEGRAIN_SSE2(3, 16, 4)
-        DEGRAIN_SSE2(3, 16, 8)
-        DEGRAIN_SSE2(3, 16, 16)
-        DEGRAIN_SSE2(3, 16, 32)
-        DEGRAIN_SSE2(3, 32, 8)
-        DEGRAIN_SSE2(3, 32, 16)
-        DEGRAIN_SSE2(3, 32, 32)
-        DEGRAIN_SSE2(3, 32, 64)
-        DEGRAIN_SSE2(3, 64, 16)
-        DEGRAIN_SSE2(3, 64, 32)
-        DEGRAIN_SSE2(3, 64, 64)
-        DEGRAIN_SSE2(3, 64, 128)
-        DEGRAIN_SSE2(3, 128, 32)
-        DEGRAIN_SSE2(3, 128, 64)
-        DEGRAIN_SSE2(3, 128, 128)
-    }
+static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions_sse2[6] = {
+    DEGRAIN_LEVEL_SSE2(1),
+    DEGRAIN_LEVEL_SSE2(2),
+    DEGRAIN_LEVEL_SSE2(3),
+    DEGRAIN_LEVEL_SSE2(4),
+    DEGRAIN_LEVEL_SSE2(5),
+    DEGRAIN_LEVEL_SSE2(6),
 };
 
 static DenoiseFunction selectDegrainFunction(unsigned radius, unsigned width, unsigned height, unsigned bits, int opt) {
@@ -597,6 +551,8 @@ static DenoiseFunction selectDegrainFunction(unsigned radius, unsigned width, un
 
 #undef DEGRAIN
 #undef DEGRAIN_SSE2
+#undef DEGRAIN_LEVEL
+#undef DEGRAIN_LEVEL_SSE2
 
 #undef KEY
 
@@ -614,11 +570,11 @@ static void selectFunctions(MVDegrainData *d) {
 
         d->ToPixels = ToPixels_uint16_t_uint8_t;
 
-        if (d->opt) {
 #if defined(MVTOOLS_X86)
+        if (d->opt) {
             d->LimitChanges = LimitChanges_sse2;
-#endif
         }
+#endif
     } else {
         d->LimitChanges = LimitChanges_C<uint16_t>;
 
@@ -710,7 +666,7 @@ static void VS_CC mvdegrainCreate(const VSMap *in, VSMap *out, void *userData, V
 
     char error[ERROR_SIZE + 1] = { 0 };
 
-    const char *vector_names[] = { "mvbw", "mvfw", "mvbw2", "mvfw2", "mvbw3", "mvfw3" };
+    const char *vector_names[] = { "mvbw", "mvfw", "mvbw2", "mvfw2", "mvbw3", "mvfw3", "mvbw4", "mvfw4", "mvbw5", "mvfw5", "mvbw6", "mvfw6"};
 
     for (int r = 0; r < radius * 2; r++) {
         d.vectors[r] = vsapi->propGetNode(in, vector_names[r], 0, NULL);
@@ -742,34 +698,31 @@ static void VS_CC mvdegrainCreate(const VSMap *in, VSMap *out, void *userData, V
         if (d.vectors_data[r].nDeltaFrame <= 0)
             snprintf(error, ERROR_SIZE, "%s", "cannot use motion vectors with absolute frame references.");
 
+#define CHECK_VECTORS(rThreshold, backwardN, forwardN, backwardP, forwardP, mvbwN, mvfwN, mvbwP, mvfwP)\
+    if (radius > rThreshold) {\
+        if (!d.vectors_data[backwardN].isBackward)\
+            snprintf(error, ERROR_SIZE, "%s", "mvbw must be generated with isb=True.");\
+        if (d.vectors_data[forwardN].isBackward)\
+            snprintf(error, ERROR_SIZE, "%s", "mvfw must be generated with isb=False.");\
+        if (d.vectors_data[backwardN].nDeltaFrame <= d.vectors_data[backwardP].nDeltaFrame)\
+            snprintf(error, ERROR_SIZE, "%s", "mvbwN must have greater delta than mvbwP.");\
+        if (d.vectors_data[forwardN].nDeltaFrame <= d.vectors_data[forwardP].nDeltaFrame)\
+            snprintf(error, ERROR_SIZE, "%s", "mvfwN must have greater delta than mvfwP.");\
+    }
+
     // Make sure the motion vector clips are correct.
     if (!d.vectors_data[Backward1].isBackward)
         snprintf(error, ERROR_SIZE, "%s", "mvbw must be generated with isb=True.");
     if (d.vectors_data[Forward1].isBackward)
         snprintf(error, ERROR_SIZE, "%s", "mvfw must be generated with isb=False.");
-    if (radius > 1) {
-        if (!d.vectors_data[Backward2].isBackward)
-            snprintf(error, ERROR_SIZE, "%s", "mvbw2 must be generated with isb=True.");
-        if (d.vectors_data[Forward2].isBackward)
-            snprintf(error, ERROR_SIZE, "%s", "mvfw2 must be generated with isb=False.");
 
-        if (d.vectors_data[Backward2].nDeltaFrame <= d.vectors_data[Backward1].nDeltaFrame)
-            snprintf(error, ERROR_SIZE, "%s", "mvbw2 must have greater delta than mvbw.");
-        if (d.vectors_data[Forward2].nDeltaFrame <= d.vectors_data[Forward1].nDeltaFrame)
-            snprintf(error, ERROR_SIZE, "%s", "mvfw2 must have greater delta than mvfw.");
-    }
-    if (radius > 2) {
-        if (!d.vectors_data[Backward3].isBackward)
-            snprintf(error, ERROR_SIZE, "%s", "mvbw3 must be generated with isb=True.");
-        if (d.vectors_data[Forward3].isBackward)
-            snprintf(error, ERROR_SIZE, "%s", "mvfw3 must be generated with isb=False.");
+    CHECK_VECTORS(1, Backward2, Forward2, Backward1, Forward1, mvbw2, mvfw2, mvbw, mvfw)
+    CHECK_VECTORS(2, Backward3, Forward3, Backward2, Forward2, mvbw3, mvfw3, mvbw2, mvfw2)
+    CHECK_VECTORS(3, Backward4, Forward4, Backward3, Forward3, mvbw4, mvfw4, mvbw3, mvfw3)
+    CHECK_VECTORS(4, Backward5, Forward5, Backward4, Forward4, mvbw5, mvfw5, mvbw4, mvfw4)
+    CHECK_VECTORS(5, Backward6, Forward6, Backward5, Forward5, mvbw6, mvfw6, mvbw5, mvfw5)
 
-        if (d.vectors_data[Backward3].nDeltaFrame <= d.vectors_data[Backward2].nDeltaFrame)
-            snprintf(error, ERROR_SIZE, "%s", "mvbw3 must have greater delta than mvbw2.");
-        if (d.vectors_data[Forward3].nDeltaFrame <= d.vectors_data[Forward2].nDeltaFrame)
-            snprintf(error, ERROR_SIZE, "%s", "mvfw3 must have greater delta than mvfw2.");
-    }
-
+#undef CHECK_VECTORS
 #undef ERROR_SIZE
 
     if (error[0]) {
@@ -968,4 +921,70 @@ extern "C" void mvdegrainsRegister(VSRegisterFunction registerFunc, VSPlugin *pl
                  "thscd2:int:opt;"
                  "opt:int:opt;",
                  mvdegrainCreate<3>, 0, plugin);
+    registerFunc("Degrain4",
+                 "clip:clip;"
+                 "super:clip;"
+                 "mvbw:clip;"
+                 "mvfw:clip;"
+                 "mvbw2:clip;"
+                 "mvfw2:clip;"
+                 "mvbw3:clip;"
+                 "mvfw3:clip;"
+                 "mvbw4:clip;"
+                 "mvfw4:clip;"
+                 "thsad:int:opt;"
+                 "thsadc:int:opt;"
+                 "plane:int:opt;"
+                 "limit:int:opt;"
+                 "limitc:int:opt;"
+                 "thscd1:int:opt;"
+                 "thscd2:int:opt;"
+                 "opt:int:opt;",
+                 mvdegrainCreate<4>, 0, plugin);
+    registerFunc("Degrain5",
+                 "clip:clip;"
+                 "super:clip;"
+                 "mvbw:clip;"
+                 "mvfw:clip;"
+                 "mvbw2:clip;"
+                 "mvfw2:clip;"
+                 "mvbw3:clip;"
+                 "mvfw3:clip;"
+                 "mvbw4:clip;"
+                 "mvfw4:clip;"
+                 "mvbw5:clip;"
+                 "mvfw5:clip;"
+                 "thsad:int:opt;"
+                 "thsadc:int:opt;"
+                 "plane:int:opt;"
+                 "limit:int:opt;"
+                 "limitc:int:opt;"
+                 "thscd1:int:opt;"
+                 "thscd2:int:opt;"
+                 "opt:int:opt;",
+                 mvdegrainCreate<5>, 0, plugin);
+    registerFunc("Degrain6",
+                 "clip:clip;"
+                 "super:clip;"
+                 "mvbw:clip;"
+                 "mvfw:clip;"
+                 "mvbw2:clip;"
+                 "mvfw2:clip;"
+                 "mvbw3:clip;"
+                 "mvfw3:clip;"
+                 "mvbw4:clip;"
+                 "mvfw4:clip;"
+                 "mvbw5:clip;"
+                 "mvfw5:clip;"
+                 "mvbw6:clip;"
+                 "mvfw6:clip;"
+                 "thsad:int:opt;"
+                 "thsadc:int:opt;"
+                 "plane:int:opt;"
+                 "limit:int:opt;"
+                 "limitc:int:opt;"
+                 "thscd1:int:opt;"
+                 "thscd2:int:opt;"
+                 "opt:int:opt;",
+                 mvdegrainCreate<6>, 0, plugin);
 }

--- a/src/MVDegrains.h
+++ b/src/MVDegrains.h
@@ -13,7 +13,13 @@ enum VectorOrder {
     Backward2,
     Forward2,
     Backward3,
-    Forward3
+    Forward3,
+    Backward4,
+    Forward4,
+    Backward5,
+    Forward5,
+    Backward6,
+    Forward6
 };
 
 
@@ -59,9 +65,10 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
 
     __m128i zero = _mm_setzero_si128();
     __m128i wsrc = _mm_set1_epi16(WSrc);
-    __m128i wrefs[6];
+    __m128i wrefs[12];
     wrefs[0] = _mm_set1_epi16(WRefs[0]);
     wrefs[1] = _mm_set1_epi16(WRefs[1]);
+    //TODO: Test sticking this in a loop. If performance is the same, a loop will massively reduce the amount of code required.
     if (radius > 1) {
         wrefs[2] = _mm_set1_epi16(WRefs[2]);
         wrefs[3] = _mm_set1_epi16(WRefs[3]);
@@ -70,12 +77,27 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
         wrefs[4] = _mm_set1_epi16(WRefs[4]);
         wrefs[5] = _mm_set1_epi16(WRefs[5]);
     }
+    if (radius > 3) {
+        wrefs[6] = _mm_set1_epi16(WRefs[6]);
+        wrefs[7] = _mm_set1_epi16(WRefs[7]);
+    }
+    if (radius > 4) {
+        wrefs[8] = _mm_set1_epi16(WRefs[8]);
+        wrefs[9] = _mm_set1_epi16(WRefs[9]);
+    }
+    if (radius > 5) {
+        wrefs[10] = _mm_set1_epi16(WRefs[10]);
+        wrefs[11] = _mm_set1_epi16(WRefs[11]);
+    }
 
-    __m128i src, refs[6];
+    __m128i src, refs[12];
 
     for (int y = 0; y < blockHeight; y++) {
         for (int x = 0; x < blockWidth; x += 8) {
-            // pDst[x] = (pRefF[x]*WRefF + pSrc[x]*WSrc + pRefB[x]*WRefB + pRefF2[x]*WRefF2 + pRefB2[x]*WRefB2 + pRefF3[x]*WRefF3 + pRefB3[x]*WRefB3 + 128)>>8;
+            // pDst[x] = (pRefF[x]*WRefF + pSrc[x]*WSrc + pRefB[x]*WRefB + 
+            //            pRefF2[x]*WRefF2 + pRefB2[x]*WRefB2 + pRefF3[x]*WRefF3 + pRefB3[x]*WRefB3
+            //            pRefF4[x]*WRefF4 + pRefB4[x]*WRefB4 + pRefF5[x]*WRefF5 + pRefB5[x]*WRefB5
+            //            pRefF6[x]*WRefF6 + pRefB6[x]*WRefB6 + 128)>>8;
 
             if (blockWidth == 4) {
                 src = _mm_cvtsi32_si128(*(const int *)pSrc);
@@ -89,6 +111,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
                     refs[4] = _mm_cvtsi32_si128(*(const int *)pRefs[4]);
                     refs[5] = _mm_cvtsi32_si128(*(const int *)pRefs[5]);
                 }
+                if (radius > 3) {
+                    refs[6] = _mm_cvtsi32_si128(*(const int *)pRefs[6]);
+                    refs[7] = _mm_cvtsi32_si128(*(const int *)pRefs[7]);
+                }
+                if (radius > 4) {
+                    refs[8] = _mm_cvtsi32_si128(*(const int *)pRefs[8]);
+                    refs[9] = _mm_cvtsi32_si128(*(const int *)pRefs[9]);
+                }
+                if (radius > 5) {
+                    refs[10] = _mm_cvtsi32_si128(*(const int *)pRefs[10]);
+                    refs[11] = _mm_cvtsi32_si128(*(const int *)pRefs[11]);
+                }
             } else {
                 src = _mm_loadl_epi64((const __m128i *)(pSrc + x));
                 refs[0] = _mm_loadl_epi64((const __m128i *)(pRefs[0] + x));
@@ -100,6 +134,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
                 if (radius > 2) {
                     refs[4] = _mm_loadl_epi64((const __m128i *)(pRefs[4] + x));
                     refs[5] = _mm_loadl_epi64((const __m128i *)(pRefs[5] + x));
+                }
+                if (radius > 3) {
+                    refs[6] = _mm_loadl_epi64((const __m128i *)(pRefs[6] + x));
+                    refs[7] = _mm_loadl_epi64((const __m128i *)(pRefs[7] + x));
+                }
+                if (radius > 4) {
+                    refs[8] = _mm_loadl_epi64((const __m128i *)(pRefs[8] + x));
+                    refs[9] = _mm_loadl_epi64((const __m128i *)(pRefs[9] + x));
+                }
+                if (radius > 5) {
+                    refs[10] = _mm_loadl_epi64((const __m128i *)(pRefs[10] + x));
+                    refs[11] = _mm_loadl_epi64((const __m128i *)(pRefs[11] + x));
                 }
             }
 
@@ -114,6 +160,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
                 refs[4] = _mm_unpacklo_epi8(refs[4], zero);
                 refs[5] = _mm_unpacklo_epi8(refs[5], zero);
             }
+            if (radius > 3) {
+                refs[6] = _mm_unpacklo_epi8(refs[6], zero);
+                refs[7] = _mm_unpacklo_epi8(refs[7], zero);
+            }
+            if (radius > 4) {
+                refs[8] = _mm_unpacklo_epi8(refs[8], zero);
+                refs[9] = _mm_unpacklo_epi8(refs[9], zero);
+            }
+            if (radius > 5) {
+                refs[10] = _mm_unpacklo_epi8(refs[10], zero);
+                refs[11] = _mm_unpacklo_epi8(refs[11], zero);
+            }
 
             src = _mm_mullo_epi16(src, wsrc);
             refs[0] = _mm_mullo_epi16(refs[0], wrefs[0]);
@@ -125,6 +183,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
             if (radius > 2) {
                 refs[4] = _mm_mullo_epi16(refs[4], wrefs[4]);
                 refs[5] = _mm_mullo_epi16(refs[5], wrefs[5]);
+            }
+            if (radius > 3) {
+                refs[6] = _mm_mullo_epi16(refs[6], wrefs[6]);
+                refs[7] = _mm_mullo_epi16(refs[7], wrefs[7]);
+            }
+            if (radius > 4) {
+                refs[8] = _mm_mullo_epi16(refs[8], wrefs[8]);
+                refs[9] = _mm_mullo_epi16(refs[9], wrefs[9]);
+            }
+            if (radius > 5) {
+                refs[10] = _mm_mullo_epi16(refs[10], wrefs[10]);
+                refs[11] = _mm_mullo_epi16(refs[11], wrefs[11]);
             }
 
             __m128i accum = _mm_set1_epi16(128);
@@ -139,6 +209,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
             if (radius > 2) {
                 accum = _mm_add_epi16(accum, refs[4]);
                 accum = _mm_add_epi16(accum, refs[5]);
+            }
+            if (radius > 3) {
+                accum = _mm_add_epi16(accum, refs[6]);
+                accum = _mm_add_epi16(accum, refs[7]);
+            }
+            if (radius > 4) {
+                accum = _mm_add_epi16(accum, refs[8]);
+                accum = _mm_add_epi16(accum, refs[9]);
+            }
+            if (radius > 5) {
+                accum = _mm_add_epi16(accum, refs[10]);
+                accum = _mm_add_epi16(accum, refs[11]);
             }
 
             accum = _mm_srli_epi16(accum, 8);
@@ -160,6 +242,18 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
         if (radius > 2) {
             pRefs[4] += nRefPitches[4];
             pRefs[5] += nRefPitches[5];
+        }
+        if (radius > 3) {
+            pRefs[6] += nRefPitches[6];
+            pRefs[7] += nRefPitches[7];
+        }
+        if (radius > 4) {
+            pRefs[8] += nRefPitches[8];
+            pRefs[9] += nRefPitches[9];
+        }
+        if (radius > 5) {
+            pRefs[10] += nRefPitches[10];
+            pRefs[11] += nRefPitches[11];
         }
     }
 }

--- a/src/MVDegrains_AVX2.cpp
+++ b/src/MVDegrains_AVX2.cpp
@@ -15,8 +15,34 @@ enum InstructionSets {
 #if defined(MVTOOLS_X86)
 #define DEGRAIN_AVX2(radius, width, height) \
     { KEY(width, height, 8, AVX2), Degrain_avx2<radius, width, height> },
+
+#define DEGRAIN_LEVEL_AVX2(radius) \
+    {\
+        DEGRAIN_AVX2(radius, 8, 2)\
+        DEGRAIN_AVX2(radius, 8, 4)\
+        DEGRAIN_AVX2(radius, 8, 8)\
+        DEGRAIN_AVX2(radius, 8, 16)\
+        DEGRAIN_AVX2(radius, 16, 1)\
+        DEGRAIN_AVX2(radius, 16, 2)\
+        DEGRAIN_AVX2(radius, 16, 4)\
+        DEGRAIN_AVX2(radius, 16, 8)\
+        DEGRAIN_AVX2(radius, 16, 16)\
+        DEGRAIN_AVX2(radius, 16, 32)\
+        DEGRAIN_AVX2(radius, 32, 8)\
+        DEGRAIN_AVX2(radius, 32, 16)\
+        DEGRAIN_AVX2(radius, 32, 32)\
+        DEGRAIN_AVX2(radius, 32, 64)\
+        DEGRAIN_AVX2(radius, 64, 16)\
+        DEGRAIN_AVX2(radius, 64, 32)\
+        DEGRAIN_AVX2(radius, 64, 64)\
+        DEGRAIN_AVX2(radius, 64, 128)\
+        DEGRAIN_AVX2(radius, 128, 32)\
+        DEGRAIN_AVX2(radius, 128, 64)\
+        DEGRAIN_AVX2(radius, 128, 128)\
+    }
 #else
 #define DEGRAIN_AVX2(radius, width, height)
+#define DEGRAIN_LEVEL_AVX2(radius)
 #endif
 
 
@@ -38,7 +64,13 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
     __m256i wrefs3 = _mm256_set1_epi16(WRefs[3]);
     __m256i wrefs4 = _mm256_set1_epi16(WRefs[4]);
     __m256i wrefs5 = _mm256_set1_epi16(WRefs[5]);
-    __m256i src, refs0, refs1, refs2, refs3, refs4, refs5;
+    __m256i wrefs6 = _mm256_set1_epi16(WRefs[6]);
+    __m256i wrefs7 = _mm256_set1_epi16(WRefs[7]);
+    __m256i wrefs8 = _mm256_set1_epi16(WRefs[8]);
+    __m256i wrefs9 = _mm256_set1_epi16(WRefs[9]);
+    __m256i wrefs10 = _mm256_set1_epi16(WRefs[10]);
+    __m256i wrefs11 = _mm256_set1_epi16(WRefs[11]);
+    __m256i src, refs0, refs1, refs2, refs3, refs4, refs5, refs6, refs7, refs8, refs9, refs10, refs11;
 
     const uint8_t *pRefs0 = pRefs[0];
     const uint8_t *pRefs1 = pRefs[1];
@@ -46,6 +78,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
     const uint8_t *pRefs3 = pRefs[3];
     const uint8_t *pRefs4 = pRefs[4];
     const uint8_t *pRefs5 = pRefs[5];
+    const uint8_t *pRefs6 = pRefs[6];
+    const uint8_t *pRefs7 = pRefs[7];
+    const uint8_t *pRefs8 = pRefs[8];
+    const uint8_t *pRefs9 = pRefs[9];
+    const uint8_t *pRefs10 = pRefs[10];
+    const uint8_t *pRefs11 = pRefs[11];
 
     int pitchMul = blockWidth == 8 ? 2 : 1;
     int nRefPitches0 = nRefPitches[0];
@@ -54,6 +92,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
     int nRefPitches3 = nRefPitches[3];
     int nRefPitches4 = nRefPitches[4];
     int nRefPitches5 = nRefPitches[5];
+    int nRefPitches6 = nRefPitches[6];
+    int nRefPitches7 = nRefPitches[7];
+    int nRefPitches8 = nRefPitches[8];
+    int nRefPitches9 = nRefPitches[9];
+    int nRefPitches10 = nRefPitches[10];
+    int nRefPitches11 = nRefPitches[11];
 
     for (int y = 0; y < blockHeight; y += pitchMul) {
         for (int x = 0; x < blockWidth; x += 16 / pitchMul) {
@@ -65,6 +109,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
                 refs3 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs3 + x)), _mm_loadl_epi64((const __m128i *)(pRefs3 + nRefPitches3 + x)))) : zero;
                 refs4 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs4 + x)), _mm_loadl_epi64((const __m128i *)(pRefs4 + nRefPitches4 + x)))) : zero;
                 refs5 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs5 + x)), _mm_loadl_epi64((const __m128i *)(pRefs5 + nRefPitches5 + x)))) : zero;
+                refs6 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs6 + x)), _mm_loadl_epi64((const __m128i *)(pRefs6 + nRefPitches6 + x)))) : zero;
+                refs7 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs7 + x)), _mm_loadl_epi64((const __m128i *)(pRefs7 + nRefPitches7 + x)))) : zero;
+                refs8 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs8 + x)), _mm_loadl_epi64((const __m128i *)(pRefs8 + nRefPitches8 + x)))) : zero;
+                refs9 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs9 + x)), _mm_loadl_epi64((const __m128i *)(pRefs9 + nRefPitches9 + x)))) : zero;
+                refs10 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs10 + x)), _mm_loadl_epi64((const __m128i *)(pRefs10 + nRefPitches10 + x)))) : zero;
+                refs11 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs11 + x)), _mm_loadl_epi64((const __m128i *)(pRefs11 + nRefPitches11 + x)))) : zero;
             } else {
                 src = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pSrc + x)));
                 refs0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs0 + x)));
@@ -73,6 +123,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
                 refs3 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs3 + x))) : zero;
                 refs4 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs4 + x))) : zero;
                 refs5 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs5 + x))) : zero;
+                refs6 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs6 + x))) : zero;
+                refs7 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs7 + x))) : zero;
+                refs8 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs8 + x))) : zero;
+                refs9 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs9 + x))) : zero;
+                refs10 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs10 + x))) : zero;
+                refs11 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs11 + x))) : zero;
             }
 
             src = _mm256_mullo_epi16(src, wsrc);
@@ -82,6 +138,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
             refs3 = radius > 1 ? _mm256_mullo_epi16(refs3, wrefs3) : refs3;
             refs4 = radius > 2 ? _mm256_mullo_epi16(refs4, wrefs4) : refs4;
             refs5 = radius > 2 ? _mm256_mullo_epi16(refs5, wrefs5) : refs5;
+            refs6 = radius > 3 ? _mm256_mullo_epi16(refs6, wrefs6) : refs6;
+            refs7 = radius > 3 ? _mm256_mullo_epi16(refs7, wrefs7) : refs7;
+            refs8 = radius > 4 ? _mm256_mullo_epi16(refs8, wrefs8) : refs8;
+            refs9 = radius > 4 ? _mm256_mullo_epi16(refs9, wrefs9) : refs9;
+            refs10 = radius > 5 ? _mm256_mullo_epi16(refs10, wrefs10) : refs10;
+            refs11 = radius > 5 ? _mm256_mullo_epi16(refs11, wrefs11) : refs11;
 
             __m256i accum = _mm256_set1_epi16(128);
 
@@ -92,6 +154,12 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
             accum = radius > 1 ? _mm256_add_epi16(accum, refs3) : accum;
             accum = radius > 2 ? _mm256_add_epi16(accum, refs4) : accum;
             accum = radius > 2 ? _mm256_add_epi16(accum, refs5) : accum;
+            accum = radius > 3 ? _mm256_add_epi16(accum, refs6) : accum;
+            accum = radius > 3 ? _mm256_add_epi16(accum, refs7) : accum;
+            accum = radius > 4 ? _mm256_add_epi16(accum, refs8) : accum;
+            accum = radius > 4 ? _mm256_add_epi16(accum, refs9) : accum;
+            accum = radius > 5 ? _mm256_add_epi16(accum, refs10) : accum;
+            accum = radius > 5 ? _mm256_add_epi16(accum, refs11) : accum;
 
             accum = _mm256_srli_epi16(accum, 8);
             accum = _mm256_packus_epi16(accum, zero);
@@ -113,80 +181,23 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
         pRefs3 += radius > 1 ? nRefPitches3 * pitchMul : 0;
         pRefs4 += radius > 2 ? nRefPitches4 * pitchMul : 0;
         pRefs5 += radius > 2 ? nRefPitches5 * pitchMul : 0;
+        pRefs6 += radius > 3 ? nRefPitches6 * pitchMul : 0;
+        pRefs7 += radius > 3 ? nRefPitches7 * pitchMul : 0;
+        pRefs8 += radius > 4 ? nRefPitches8 * pitchMul : 0;
+        pRefs9 += radius > 4 ? nRefPitches9 * pitchMul : 0;
+        pRefs10 += radius > 5 ? nRefPitches10 * pitchMul : 0;
+        pRefs11 += radius > 5 ? nRefPitches11 * pitchMul : 0;
     }
 }
 #endif
 
-static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions[3] = {
-    {
-        DEGRAIN_AVX2(1, 8, 2)
-        DEGRAIN_AVX2(1, 8, 4)
-        DEGRAIN_AVX2(1, 8, 8)
-        DEGRAIN_AVX2(1, 8, 16)
-        DEGRAIN_AVX2(1, 16, 1)
-        DEGRAIN_AVX2(1, 16, 2)
-        DEGRAIN_AVX2(1, 16, 4)
-        DEGRAIN_AVX2(1, 16, 8)
-        DEGRAIN_AVX2(1, 16, 16)
-        DEGRAIN_AVX2(1, 16, 32)
-        DEGRAIN_AVX2(1, 32, 8)
-        DEGRAIN_AVX2(1, 32, 16)
-        DEGRAIN_AVX2(1, 32, 32)
-        DEGRAIN_AVX2(1, 32, 64)
-        DEGRAIN_AVX2(1, 64, 16)
-        DEGRAIN_AVX2(1, 64, 32)
-        DEGRAIN_AVX2(1, 64, 64)
-        DEGRAIN_AVX2(1, 64, 128)
-        DEGRAIN_AVX2(1, 128, 32)
-        DEGRAIN_AVX2(1, 128, 64)
-        DEGRAIN_AVX2(1, 128, 128)
-    },
-    {
-        DEGRAIN_AVX2(2, 8, 2)
-        DEGRAIN_AVX2(2, 8, 4)
-        DEGRAIN_AVX2(2, 8, 8)
-        DEGRAIN_AVX2(2, 8, 16)
-        DEGRAIN_AVX2(2, 16, 1)
-        DEGRAIN_AVX2(2, 16, 2)
-        DEGRAIN_AVX2(2, 16, 4)
-        DEGRAIN_AVX2(2, 16, 8)
-        DEGRAIN_AVX2(2, 16, 16)
-        DEGRAIN_AVX2(2, 16, 32)
-        DEGRAIN_AVX2(2, 32, 8)
-        DEGRAIN_AVX2(2, 32, 16)
-        DEGRAIN_AVX2(2, 32, 32)
-        DEGRAIN_AVX2(2, 32, 64)
-        DEGRAIN_AVX2(2, 64, 16)
-        DEGRAIN_AVX2(2, 64, 32)
-        DEGRAIN_AVX2(2, 64, 64)
-        DEGRAIN_AVX2(2, 64, 128)
-        DEGRAIN_AVX2(2, 128, 32)
-        DEGRAIN_AVX2(2, 128, 64)
-        DEGRAIN_AVX2(2, 128, 128)
-    },
-    {
-        DEGRAIN_AVX2(3, 8, 2)
-        DEGRAIN_AVX2(3, 8, 4)
-        DEGRAIN_AVX2(3, 8, 8)
-        DEGRAIN_AVX2(3, 8, 16)
-        DEGRAIN_AVX2(3, 16, 1)
-        DEGRAIN_AVX2(3, 16, 2)
-        DEGRAIN_AVX2(3, 16, 4)
-        DEGRAIN_AVX2(3, 16, 8)
-        DEGRAIN_AVX2(3, 16, 16)
-        DEGRAIN_AVX2(3, 16, 32)
-        DEGRAIN_AVX2(3, 32, 8)
-        DEGRAIN_AVX2(3, 32, 16)
-        DEGRAIN_AVX2(3, 32, 32)
-        DEGRAIN_AVX2(3, 32, 64)
-        DEGRAIN_AVX2(3, 64, 16)
-        DEGRAIN_AVX2(3, 64, 32)
-        DEGRAIN_AVX2(3, 64, 64)
-        DEGRAIN_AVX2(3, 64, 128)
-        DEGRAIN_AVX2(3, 128, 32)
-        DEGRAIN_AVX2(3, 128, 64)
-        DEGRAIN_AVX2(3, 128, 128)
-    }
+static const std::unordered_map<uint32_t, DenoiseFunction> degrain_functions[6] = {
+    DEGRAIN_LEVEL_AVX2(1),
+    DEGRAIN_LEVEL_AVX2(2),
+    DEGRAIN_LEVEL_AVX2(3),
+    DEGRAIN_LEVEL_AVX2(4),
+    DEGRAIN_LEVEL_AVX2(5),
+    DEGRAIN_LEVEL_AVX2(6),
 };
 
 DenoiseFunction selectDegrainFunctionAVX2(unsigned radius, unsigned width, unsigned height, unsigned bits) {


### PR DESCRIPTION
(Happy new year!)

There's a few code cleanups left, particularly now because we support a radius of 6, so all of the "if radius > X" logic is a bit of an eye sore and bug prone. I'll be posting a follow up CR for switching to using loops where appropriate, but I wanted to provide this PR as is, as it follows the existing implementation patterns and is thus easier to review.

I've tested this on everything from SD to HD to UHD footage and it all seems to work as expected.

In the future I'd like to add MDegrainN support, but starting with just a radius of 1-6 support and forwarding it along to MDegrain1-6 under the hood, which is what the Avisynth version currently does. This would provide a simpler API for working with variable radiuses and should be doable rather cheapely. Additional work would be required for proper MDegrainN (>6) support.

I'll take a look at adding blocksize 24 (12, 48, etc) support as well, although that will likely be a C-only change for now.