### PR TITLE
Loops everywhere - Cleanup init in GetFrame and Degrain SSE2 code

### DIFF
--- a/src/MVDegrains.cpp
+++ b/src/MVDegrains.cpp
@@ -96,96 +96,22 @@ static const VSFrameRef *VS_CC mvdegrainGetFrame(int n, int activationReason, vo
     MVDegrainData *d = (MVDegrainData *)*instanceData;
 
     if (activationReason == arInitial) {
-        //TODO: Clean this up to just use a loop.
-        if (radius > 5)
-            vsapi->requestFrameFilter(n, d->vectors[Forward6], frameCtx);
-        if (radius > 4)
-            vsapi->requestFrameFilter(n, d->vectors[Forward5], frameCtx);
-        if (radius > 3)
-            vsapi->requestFrameFilter(n, d->vectors[Forward4], frameCtx);
-        if (radius > 2)
-            vsapi->requestFrameFilter(n, d->vectors[Forward3], frameCtx);
-        if (radius > 1)
-            vsapi->requestFrameFilter(n, d->vectors[Forward2], frameCtx);
-        vsapi->requestFrameFilter(n, d->vectors[Forward1], frameCtx);
-        vsapi->requestFrameFilter(n, d->vectors[Backward1], frameCtx);
-        if (radius > 1)
-            vsapi->requestFrameFilter(n, d->vectors[Backward2], frameCtx);
-        if (radius > 2)
-            vsapi->requestFrameFilter(n, d->vectors[Backward3], frameCtx);
-        if (radius > 3)
-            vsapi->requestFrameFilter(n, d->vectors[Backward4], frameCtx);
-        if (radius > 4)
-            vsapi->requestFrameFilter(n, d->vectors[Backward5], frameCtx);
-        if (radius > 5)
-            vsapi->requestFrameFilter(n, d->vectors[Backward6], frameCtx);
 
-        if (radius > 5) {
-            int offF6 = -1 * d->vectors_data[Forward6].nDeltaFrame;
-            if (n + offF6 >= 0)
-                vsapi->requestFrameFilter(n + offF6, d->super, frameCtx);
-        }
+        for (int r = 0; r < radius * 2; r += 2) {
+            //Backward
+            vsapi->requestFrameFilter(n, d->vectors[r], frameCtx);
+            //Forward
+            vsapi->requestFrameFilter(n, d->vectors[r + 1], frameCtx);
 
-        if (radius > 4) {
-            int offF5 = -1 * d->vectors_data[Forward5].nDeltaFrame;
-            if (n + offF5 >= 0)
-                vsapi->requestFrameFilter(n + offF5, d->super, frameCtx);
-        }
+            // Backward
+            int offB = d->vectors_data[r].nDeltaFrame;
+            if (n + offB < d->vi->numFrames)
+                vsapi->requestFrameFilter(n + offB, d->super, frameCtx);
 
-        if (radius > 3) {
-            int offF4 = -1 * d->vectors_data[Forward4].nDeltaFrame;
-            if (n + offF4 >= 0)
-                vsapi->requestFrameFilter(n + offF4, d->super, frameCtx);
-        }
-
-        if (radius > 2) {
-            int offF3 = -1 * d->vectors_data[Forward3].nDeltaFrame;
-            if (n + offF3 >= 0)
-                vsapi->requestFrameFilter(n + offF3, d->super, frameCtx);
-        }
-
-        if (radius > 1) {
-            int offF2 = -1 * d->vectors_data[Forward2].nDeltaFrame;
-            if (n + offF2 >= 0)
-                vsapi->requestFrameFilter(n + offF2, d->super, frameCtx);
-        }
-
-        int offF = -1 * d->vectors_data[Forward1].nDeltaFrame;
-        if (n + offF >= 0)
-            vsapi->requestFrameFilter(n + offF, d->super, frameCtx);
-
-        int offB = d->vectors_data[Backward1].nDeltaFrame;
-        if (n + offB < d->vi->numFrames)
-            vsapi->requestFrameFilter(n + offB, d->super, frameCtx);
-
-        if (radius > 1) {
-            int offB2 = d->vectors_data[Backward2].nDeltaFrame;
-            if (n + offB2 < d->vi->numFrames)
-                vsapi->requestFrameFilter(n + offB2, d->super, frameCtx);
-        }
-
-        if (radius > 2) {
-            int offB3 = d->vectors_data[Backward3].nDeltaFrame;
-            if (n + offB3 < d->vi->numFrames)
-                vsapi->requestFrameFilter(n + offB3, d->super, frameCtx);
-        }
-
-        if (radius > 3) {
-            int offB4 = d->vectors_data[Backward4].nDeltaFrame;
-            if (n + offB4 < d->vi->numFrames)
-                vsapi->requestFrameFilter(n + offB4, d->super, frameCtx);
-        }
-
-        if (radius > 4) {
-            int offB5 = d->vectors_data[Backward5].nDeltaFrame;
-            if (n + offB5 < d->vi->numFrames)
-                vsapi->requestFrameFilter(n + offB5, d->super, frameCtx);
-        }
-
-        if (radius > 5) {
-            int offB6 = d->vectors_data[Backward6].nDeltaFrame;
-            if (n + offB6 < d->vi->numFrames)
-                vsapi->requestFrameFilter(n + offB6, d->super, frameCtx);
+            // Forward
+            int offF = -1 * d->vectors_data[r + 1].nDeltaFrame;
+            if (n + offF >= 0)
+                vsapi->requestFrameFilter(n + offF, d->super, frameCtx);
         }
 
         vsapi->requestFrameFilter(n, d->node, frameCtx);

--- a/src/MVDegrains.h
+++ b/src/MVDegrains.h
@@ -65,7 +65,7 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
 
     __m128i zero = _mm_setzero_si128();
     __m128i wsrc = _mm_set1_epi16(WSrc);
-    __m128i wrefs[radius * 2];
+    __m128i wrefs[12];
 
     // We intentionally jump by 2 (here and below), as it delineates groups of
     // backward/forward and ALSO produces testably faster code.
@@ -74,7 +74,7 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
         wrefs[i + 1] = _mm_set1_epi16(WRefs[i + 1]);
     }
 
-    __m128i src, accum, refs[radius * 2];
+    __m128i src, accum, refs[12];
 
     for (int y = 0; y < blockHeight; y++) {
         for (int x = 0; x < blockWidth; x += 8) {

--- a/src/MVDegrains.h
+++ b/src/MVDegrains.h
@@ -74,7 +74,7 @@ static void Degrain_sse2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
         wrefs[i + 1] = _mm_set1_epi16(WRefs[i + 1]);
     }
 
-    __m128i src, accum, refs[12];
+    __m128i src, accum, refs[radius * 2];
 
     for (int y = 0; y < blockHeight; y++) {
         for (int x = 0; x < blockWidth; x += 8) {


### PR DESCRIPTION
This is purely cosmetics. There should be no logic changes.

I tested this with a 4k, 2k, and 540p video. I could find no discernable
difference in performance between the two, and it takes up a lot less
code.

Results:
Degrain6 SSE2 WITHOUT loops on 8-bit, 1000 frames
540p = 77.5433
1080p = 50.5460
4k = 12.0173

Degrain6 SSE2 WITH loops on 8-bit, 1000 frames
540p = 79.3693
1080p = 49.8574
4k = 11.9895

This is with GCC 12.2.0 on Arch Linux.

---
Edit: Most recent commit is even faster:

 Eliminate a loop in Degrain SSE2, providing even better performance.

Small improvement over the previous commit. We're looping one less time
and gain a small speed boost.

Interestingly, I tried eliminating even more loops (like the accum
loop), eliminating temp variables, and a few other things, and it was
always slower. This version of the code is a quite simple change and is
the fastest. Who'dda thunk.

Tested with MDegrain6 on 4k, 8-bit footage with 8 and 16 size blocks,
espectively. Forced to use SSE2 by commenting out all other code paths.

GCC 12.2.0

Slower runs are blksize 8, faster runs are blksize 16.

Before:

```sh
/mnt/.../Footage/test >>> hyperfine --show-output -r 3 -P output 1 2 'vspipe -p -e 500 -o {output} tester.vpy /dev/null'
Benchmark 1: vspipe -p -e 500 -o 1 tester.vpy /dev/null
Script evaluation done in 3.27 seconds
Output 501 frames in 80.49 seconds (6.22 fps)
Script evaluation done in 3.31 seconds
Output 501 frames in 80.83 seconds (6.20 fps)
Script evaluation done in 3.29 seconds
Output 501 frames in 80.85 seconds (6.20 fps)
  Time (mean ± σ):     84.266 s ±  0.227 s    [User: 3817.761 s, System: 6.674 s]
  Range (min … max):   84.004 s … 84.405 s    3 runs

Benchmark 2: vspipe -p -e 500 -o 2 tester.vpy /dev/null
Script evaluation done in 3.33 seconds
Output 501 frames in 28.30 seconds (17.70 fps)
Script evaluation done in 3.30 seconds
Output 501 frames in 28.25 seconds (17.74 fps)
Script evaluation done in 3.33 seconds
Output 501 frames in 28.16 seconds (17.79 fps)
  Time (mean ± σ):     31.790 s ±  0.072 s    [User: 1331.485 s, System: 5.238 s]
  Range (min … max):   31.722 s … 31.866 s    3 runs

Summary
  'vspipe -p -e 500 -o 2 tester.vpy /dev/null' ran
    2.65 ± 0.01 times faster than 'vspipe -p -e 500 -o 1 tester.vpy /dev/null'
```

After:

```sh
/mnt/.../Footage/test >>> hyperfine --show-output -r 3 -P output 1 2 'vspipe -p -e 500 -o {output} tester.vpy /dev/null'                           [130]
Benchmark 1: vspipe -p -e 500 -o 1 tester.vpy /dev/null
Script evaluation done in 3.24 seconds
Output 501 frames in 79.45 seconds (6.31 fps)
Script evaluation done in 3.29 seconds
Output 501 frames in 79.88 seconds (6.27 fps)
Script evaluation done in 3.30 seconds
Output 501 frames in 79.77 seconds (6.28 fps)
  Time (mean ± σ):     83.235 s ±  0.255 s    [User: 3772.476 s, System: 7.349 s]
  Range (min … max):   82.948 s … 83.434 s    3 runs

Benchmark 2: vspipe -p -e 500 -o 2 tester.vpy /dev/null
Script evaluation done in 3.31 seconds
Output 501 frames in 27.66 seconds (18.12 fps)
Script evaluation done in 3.28 seconds
Output 501 frames in 27.71 seconds (18.08 fps)
Script evaluation done in 3.30 seconds
Output 501 frames in 27.65 seconds (18.12 fps)
  Time (mean ± σ):     31.199 s ±  0.023 s    [User: 1303.617 s, System: 5.921 s]
  Range (min … max):   31.181 s … 31.224 s    3 runs

Summary
  'vspipe -p -e 500 -o 2 tester.vpy /dev/null' ran
    2.67 ± 0.01 times faster than 'vspipe -p -e 500 -o 1 tester.vpy /dev/null'
```