### PR TITLE
Update x264 ASM to latest version.

### DIFF
--- a/src/asm/const-a.asm
+++ b/src/asm/const-a.asm
@@ -1,7 +1,7 @@
 ;*****************************************************************************
 ;* const-a.asm: x86 global constants
 ;*****************************************************************************
-;* Copyright (C) 2010-2018 x264 project
+;* Copyright (C) 2010-2022 x264 project
 ;*
 ;* Authors: Loren Merritt <lorenm@u.washington.edu>
 ;*          Fiona Glaser <fiona@x264.com>
@@ -56,7 +56,7 @@ const pw_4,        times 8 dw 4
 const pw_8,        times 8 dw 8
 const pw_64,       times 8 dw 64
 const pw_256,      times 8 dw 256
-const pw_32_0,     times 4 dw 32,
+const pw_32_0,     times 4 dw 32
                    times 4 dw 0
 const pw_8000,     times 8 dw 0x8000
 const pw_3fff,     times 8 dw 0x3fff

--- a/src/asm/cpu-a.asm
+++ b/src/asm/cpu-a.asm
@@ -1,7 +1,7 @@
 ;*****************************************************************************
 ;* cpu-a.asm: x86 cpu utilities
 ;*****************************************************************************
-;* Copyright (C) 2003-2018 x264 project
+;* Copyright (C) 2003-2022 x264 project
 ;*
 ;* Authors: Laurent Aimar <fenrir@via.ecp.fr>
 ;*          Loren Merritt <lorenm@u.washington.edu>
@@ -64,28 +64,21 @@ cglobal cpu_xgetbv
 %endif
     ret
 
-%if ARCH_X86_64
-
 ;-----------------------------------------------------------------------------
-; void stack_align( void (*func)(void*), void *arg );
+; void cpu_emms( void )
 ;-----------------------------------------------------------------------------
-cglobal stack_align
-    push rbp
-    mov  rbp, rsp
-%if WIN64
-    sub  rsp, 32 ; shadow space
-%endif
-    and  rsp, ~(STACK_ALIGNMENT-1)
-    mov  rax, r0
-    mov   r0, r1
-    mov   r1, r2
-    mov   r2, r3
-    call rax
-    leave
+cglobal cpu_emms
+    emms
     ret
 
-%else
+;-----------------------------------------------------------------------------
+; void cpu_sfence( void )
+;-----------------------------------------------------------------------------
+cglobal cpu_sfence
+    sfence
+    ret
 
+%if ARCH_X86_64 == 0
 ;-----------------------------------------------------------------------------
 ; int cpu_cpuid_test( void )
 ; return 0 if unsupported
@@ -111,35 +104,4 @@ cglobal cpu_cpuid_test
     pop     ebx
     popfd
     ret
-
-cglobal stack_align
-    push ebp
-    mov  ebp, esp
-    sub  esp, 12
-    and  esp, ~(STACK_ALIGNMENT-1)
-    mov  ecx, [ebp+8]
-    mov  edx, [ebp+12]
-    mov  [esp], edx
-    mov  edx, [ebp+16]
-    mov  [esp+4], edx
-    mov  edx, [ebp+20]
-    mov  [esp+8], edx
-    call ecx
-    leave
-    ret
-
 %endif
-
-;-----------------------------------------------------------------------------
-; void cpu_emms( void )
-;-----------------------------------------------------------------------------
-cglobal cpu_emms
-    emms
-    ret
-
-;-----------------------------------------------------------------------------
-; void cpu_sfence( void )
-;-----------------------------------------------------------------------------
-cglobal cpu_sfence
-    sfence
-    ret

--- a/src/asm/pixel-32.asm
+++ b/src/asm/pixel-32.asm
@@ -1,7 +1,7 @@
 ;*****************************************************************************
 ;* pixel-32.asm: x86_32 pixel metrics
 ;*****************************************************************************
-;* Copyright (C) 2003-2018 x264 project
+;* Copyright (C) 2003-2022 x264 project
 ;*
 ;* Authors: Loren Merritt <lorenm@u.washington.edu>
 ;*          Laurent Aimar <fenrir@via.ecp.fr>
@@ -347,7 +347,7 @@ cglobal intra_sa8d_x3_8x8, 2,3
     paddw    m2, m4 ; v
 
     SUM_MM_X3 m0, m1, m2, m3, m4, m5, m6, pavgw
-    mov      r2d, r2m
+    mov      r2, r2m
     pxor      m7, m7
     punpckldq m2, m1
     pavgw     m0, m7
@@ -368,13 +368,13 @@ cglobal intra_sa8d_x3_8x8, 2,3
 ;                             const uint8_t *pix2, intptr_t stride2, int sums[2][4] )
 ;-----------------------------------------------------------------------------
 cglobal pixel_ssim_4x4x2_core, 0,5
-    mov       r1d, r1m
-    mov       r3d, r3m
+    mov       r1, r1m
+    mov       r3, r3m
     mov       r4, 4
     pxor      m0, m0
 .loop:
-    mov       r0d, r0m
-    mov       r2d, r2m
+    mov       r0, r0m
+    mov       r2, r2m
     add       r0, r4
     add       r2, r4
     pxor      m1, m1

--- a/src/asm/sad-a.asm
+++ b/src/asm/sad-a.asm
@@ -1,7 +1,7 @@
 ;*****************************************************************************
 ;* sad-a.asm: x86 sad functions
 ;*****************************************************************************
-;* Copyright (C) 2003-2018 x264 project
+;* Copyright (C) 2003-2022 x264 project
 ;*
 ;* Authors: Loren Merritt <lorenm@u.washington.edu>
 ;*          Fiona Glaser <fiona@x264.com>
@@ -1920,7 +1920,7 @@ cglobal pixel_sad_16x%2_cache64_%1
     shl     r4d, 4  ; code size = 80
 %endif
 %define sad_w16_addr (sad_w16_align1_%1 + (sad_w16_align1_%1 - sad_w16_align2_%1))
-%ifdef PIC
+%if ARCH_X86_64
     lea     r5, [sad_w16_addr]
     add     r5, r4
 %else


### PR DESCRIPTION
Seems to be about the same speed (maybe *slightly* faster), and more importantly fixes all of the NASM build spam we were getting before.

Also opens up the door to potentially use AVX2 SAD functions, although I have yet to experiment with integrating these.

This is all literally copy-paste from the x264 project.