### PR TITLE
Cleanup Degrain AVX, similar to SSE2 code.

### DIFF
--- a/src/MVDegrains_AVX2.cpp
+++ b/src/MVDegrains_AVX2.cpp
@@ -58,109 +58,45 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
 
     __m256i zero = _mm256_setzero_si256();
     __m256i wsrc = _mm256_set1_epi16(WSrc);
-    __m256i wrefs0 = _mm256_set1_epi16(WRefs[0]);
-    __m256i wrefs1 = _mm256_set1_epi16(WRefs[1]);
-    __m256i wrefs2 = _mm256_set1_epi16(WRefs[2]);
-    __m256i wrefs3 = _mm256_set1_epi16(WRefs[3]);
-    __m256i wrefs4 = _mm256_set1_epi16(WRefs[4]);
-    __m256i wrefs5 = _mm256_set1_epi16(WRefs[5]);
-    __m256i wrefs6 = _mm256_set1_epi16(WRefs[6]);
-    __m256i wrefs7 = _mm256_set1_epi16(WRefs[7]);
-    __m256i wrefs8 = _mm256_set1_epi16(WRefs[8]);
-    __m256i wrefs9 = _mm256_set1_epi16(WRefs[9]);
-    __m256i wrefs10 = _mm256_set1_epi16(WRefs[10]);
-    __m256i wrefs11 = _mm256_set1_epi16(WRefs[11]);
-    __m256i src, refs0, refs1, refs2, refs3, refs4, refs5, refs6, refs7, refs8, refs9, refs10, refs11;
 
-    const uint8_t *pRefs0 = pRefs[0];
-    const uint8_t *pRefs1 = pRefs[1];
-    const uint8_t *pRefs2 = pRefs[2];
-    const uint8_t *pRefs3 = pRefs[3];
-    const uint8_t *pRefs4 = pRefs[4];
-    const uint8_t *pRefs5 = pRefs[5];
-    const uint8_t *pRefs6 = pRefs[6];
-    const uint8_t *pRefs7 = pRefs[7];
-    const uint8_t *pRefs8 = pRefs[8];
-    const uint8_t *pRefs9 = pRefs[9];
-    const uint8_t *pRefs10 = pRefs[10];
-    const uint8_t *pRefs11 = pRefs[11];
+    __m256i wrefs[12];
+    for(int i = 0; i < radius * 2; i += 2) {
+        wrefs[i] = _mm256_set1_epi16(WRefs[i]);
+        wrefs[i + 1] = _mm256_set1_epi16(WRefs[i + 1]);
+    }
+    __m256i src, accum, refs[12];
 
     int pitchMul = blockWidth == 8 ? 2 : 1;
-    int nRefPitches0 = nRefPitches[0];
-    int nRefPitches1 = nRefPitches[1];
-    int nRefPitches2 = nRefPitches[2];
-    int nRefPitches3 = nRefPitches[3];
-    int nRefPitches4 = nRefPitches[4];
-    int nRefPitches5 = nRefPitches[5];
-    int nRefPitches6 = nRefPitches[6];
-    int nRefPitches7 = nRefPitches[7];
-    int nRefPitches8 = nRefPitches[8];
-    int nRefPitches9 = nRefPitches[9];
-    int nRefPitches10 = nRefPitches[10];
-    int nRefPitches11 = nRefPitches[11];
 
     for (int y = 0; y < blockHeight; y += pitchMul) {
         for (int x = 0; x < blockWidth; x += 16 / pitchMul) {
             if (blockWidth == 8) {
                 src = _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pSrc + x)), _mm_loadl_epi64((const __m128i *)(pSrc + nSrcPitch + x))));
-                refs0 = _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs0 + x)), _mm_loadl_epi64((const __m128i *)(pRefs0 + nRefPitches0 + x))));
-                refs1 = _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs1 + x)), _mm_loadl_epi64((const __m128i *)(pRefs1 + nRefPitches1 + x))));
-                refs2 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs2 + x)), _mm_loadl_epi64((const __m128i *)(pRefs2 + nRefPitches2 + x)))) : zero;
-                refs3 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs3 + x)), _mm_loadl_epi64((const __m128i *)(pRefs3 + nRefPitches3 + x)))) : zero;
-                refs4 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs4 + x)), _mm_loadl_epi64((const __m128i *)(pRefs4 + nRefPitches4 + x)))) : zero;
-                refs5 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs5 + x)), _mm_loadl_epi64((const __m128i *)(pRefs5 + nRefPitches5 + x)))) : zero;
-                refs6 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs6 + x)), _mm_loadl_epi64((const __m128i *)(pRefs6 + nRefPitches6 + x)))) : zero;
-                refs7 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs7 + x)), _mm_loadl_epi64((const __m128i *)(pRefs7 + nRefPitches7 + x)))) : zero;
-                refs8 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs8 + x)), _mm_loadl_epi64((const __m128i *)(pRefs8 + nRefPitches8 + x)))) : zero;
-                refs9 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs9 + x)), _mm_loadl_epi64((const __m128i *)(pRefs9 + nRefPitches9 + x)))) : zero;
-                refs10 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs10 + x)), _mm_loadl_epi64((const __m128i *)(pRefs10 + nRefPitches10 + x)))) : zero;
-                refs11 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs11 + x)), _mm_loadl_epi64((const __m128i *)(pRefs11 + nRefPitches11 + x)))) : zero;
+                for(int i = 0; i < radius * 2; i += 2) {
+                    refs[i] = _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs[i] + x)), _mm_loadl_epi64((const __m128i *)(pRefs[i] + nRefPitches[i] + x))));
+                    refs[i + 1] = _mm256_cvtepu8_epi16(_mm_unpacklo_epi64(_mm_loadl_epi64((const __m128i *)(pRefs[i + 1] + x)), _mm_loadl_epi64((const __m128i *)(pRefs[i + 1] + nRefPitches[i + 1] + x))));
+                }
             } else {
                 src = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pSrc + x)));
-                refs0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs0 + x)));
-                refs1 = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs1 + x)));
-                refs2 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs2 + x))) : zero;
-                refs3 = radius > 1 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs3 + x))) : zero;
-                refs4 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs4 + x))) : zero;
-                refs5 = radius > 2 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs5 + x))) : zero;
-                refs6 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs6 + x))) : zero;
-                refs7 = radius > 3 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs7 + x))) : zero;
-                refs8 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs8 + x))) : zero;
-                refs9 = radius > 4 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs9 + x))) : zero;
-                refs10 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs10 + x))) : zero;
-                refs11 = radius > 5 ? _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs11 + x))) : zero;
+                for(int i = 0; i < radius * 2; i += 2) {
+                    refs[i] = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs[i] + x)));
+                    refs[i + 1] = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *)(pRefs[i + 1] + x)));
+                }
             }
 
             src = _mm256_mullo_epi16(src, wsrc);
-            refs0 = _mm256_mullo_epi16(refs0, wrefs0);
-            refs1 = _mm256_mullo_epi16(refs1, wrefs1);
-            refs2 = radius > 1 ? _mm256_mullo_epi16(refs2, wrefs2) : refs2;
-            refs3 = radius > 1 ? _mm256_mullo_epi16(refs3, wrefs3) : refs3;
-            refs4 = radius > 2 ? _mm256_mullo_epi16(refs4, wrefs4) : refs4;
-            refs5 = radius > 2 ? _mm256_mullo_epi16(refs5, wrefs5) : refs5;
-            refs6 = radius > 3 ? _mm256_mullo_epi16(refs6, wrefs6) : refs6;
-            refs7 = radius > 3 ? _mm256_mullo_epi16(refs7, wrefs7) : refs7;
-            refs8 = radius > 4 ? _mm256_mullo_epi16(refs8, wrefs8) : refs8;
-            refs9 = radius > 4 ? _mm256_mullo_epi16(refs9, wrefs9) : refs9;
-            refs10 = radius > 5 ? _mm256_mullo_epi16(refs10, wrefs10) : refs10;
-            refs11 = radius > 5 ? _mm256_mullo_epi16(refs11, wrefs11) : refs11;
+            for(int i = 0; i < radius * 2; i += 2) {
+                refs[i] = _mm256_mullo_epi16(refs[i], wrefs[i]);
+                refs[i + 1] = _mm256_mullo_epi16(refs[i + 1], wrefs[i + 1]);
+            }
 
-            __m256i accum = _mm256_set1_epi16(128);
-
+            accum = _mm256_set1_epi16(128);
             accum = _mm256_add_epi16(accum, src);
-            accum = _mm256_add_epi16(accum, refs0);
-            accum = _mm256_add_epi16(accum, refs1);
-            accum = radius > 1 ? _mm256_add_epi16(accum, refs2) : accum;
-            accum = radius > 1 ? _mm256_add_epi16(accum, refs3) : accum;
-            accum = radius > 2 ? _mm256_add_epi16(accum, refs4) : accum;
-            accum = radius > 2 ? _mm256_add_epi16(accum, refs5) : accum;
-            accum = radius > 3 ? _mm256_add_epi16(accum, refs6) : accum;
-            accum = radius > 3 ? _mm256_add_epi16(accum, refs7) : accum;
-            accum = radius > 4 ? _mm256_add_epi16(accum, refs8) : accum;
-            accum = radius > 4 ? _mm256_add_epi16(accum, refs9) : accum;
-            accum = radius > 5 ? _mm256_add_epi16(accum, refs10) : accum;
-            accum = radius > 5 ? _mm256_add_epi16(accum, refs11) : accum;
 
+            for(int i = 0; i < radius * 2; i += 2) {
+                accum = _mm256_add_epi16(accum, refs[i]);
+                accum = _mm256_add_epi16(accum, refs[i + 1]);
+            }
             accum = _mm256_srli_epi16(accum, 8);
             accum = _mm256_packus_epi16(accum, zero);
 
@@ -175,18 +111,11 @@ static void Degrain_avx2(uint8_t *pDst, int nDstPitch, const uint8_t *pSrc, int 
 
         pDst += nDstPitch * pitchMul;
         pSrc += nSrcPitch * pitchMul;
-        pRefs0 += nRefPitches0 * pitchMul;
-        pRefs1 += nRefPitches1 * pitchMul;
-        pRefs2 += radius > 1 ? nRefPitches2 * pitchMul : 0;
-        pRefs3 += radius > 1 ? nRefPitches3 * pitchMul : 0;
-        pRefs4 += radius > 2 ? nRefPitches4 * pitchMul : 0;
-        pRefs5 += radius > 2 ? nRefPitches5 * pitchMul : 0;
-        pRefs6 += radius > 3 ? nRefPitches6 * pitchMul : 0;
-        pRefs7 += radius > 3 ? nRefPitches7 * pitchMul : 0;
-        pRefs8 += radius > 4 ? nRefPitches8 * pitchMul : 0;
-        pRefs9 += radius > 4 ? nRefPitches9 * pitchMul : 0;
-        pRefs10 += radius > 5 ? nRefPitches10 * pitchMul : 0;
-        pRefs11 += radius > 5 ? nRefPitches11 * pitchMul : 0;
+
+        for(int i = 0; i < radius * 2; i += 2) {
+            pRefs[i] += nRefPitches[i] * pitchMul;
+            pRefs[i + 1] += nRefPitches[i + 1] * pitchMul;
+        }
     }
 }
 #endif


### PR DESCRIPTION
Consider this optional - it's a nice code cleanup, but maybe the perf hit is unacceptable?

There is no major change in performance. The new code is *slightly* slower, but we're talking very small differences here, like maybe ~1%.

Tests run on blocksize 8 and 16.

When looking at the benchmarks, the key is to look at the comparisons between the old and new AVX code. I can provide specific FPS numbers, but I went with the summary below to keep things succinct. 

Here are some numbers for 540p and 1080p. Note the `mvversion` arg for oldavx vs newavx:

```
Summary
  'vspipe -p -e 3000 -o 2 --arg mvversion=oldavx --arg src=test-540p.dgi tester.vpy /dev/null' ran
    1.00 ± 0.00 times faster than 'vspipe -p -e 3000 -o 2 --arg mvversion=newavx --arg src=test-540p.dgi tester.vpy /dev/null'
    2.69 ± 0.01 times faster than 'vspipe -p -e 3000 -o 1 --arg mvversion=oldavx --arg src=test-540p.dgi tester.vpy /dev/null'
    2.70 ± 0.00 times faster than 'vspipe -p -e 3000 -o 1 --arg mvversion=newavx --arg src=test-540p.dgi tester.vpy /dev/null'
    3.14 ± 0.01 times faster than 'vspipe -p -e 3000 -o 2 --arg mvversion=oldavx --arg src=test-1080p.dgi tester.vpy /dev/null'
    3.15 ± 0.01 times faster than 'vspipe -p -e 3000 -o 2 --arg mvversion=newavx --arg src=test-1080p.dgi tester.vpy /dev/null'
    8.88 ± 0.04 times faster than 'vspipe -p -e 3000 -o 1 --arg mvversion=oldavx --arg src=test-1080p.dgi tester.vpy /dev/null'
    8.89 ± 0.02 times faster than 'vspipe -p -e 3000 -o 1 --arg mvversion=newavx --arg src=test-1080p.dgi tester.vpy /dev/null'
```

Same thing for 4k:
```
Summary
  'vspipe -p -e 500 -o 2 --arg mvversion=oldavx --arg src=test-4k.dgi tester.vpy /dev/null' ran
    1.01 ± 0.00 times faster than 'vspipe -p -e 500 -o 2 --arg mvversion=newavx --arg src=test-4k.dgi tester.vpy /dev/null'
    2.69 ± 0.00 times faster than 'vspipe -p -e 500 -o 1 --arg mvversion=oldavx --arg src=test-4k.dgi tester.vpy /dev/null'
    2.69 ± 0.00 times faster than 'vspipe -p -e 500 -o 1 --arg mvversion=newavx --arg src=test-4k.dgi tester.vpy /dev/null'

```