### PR TITLE
Fix bug in Cross Search.

### DIFF
--- a/src/PlaneOfBlocks.cpp
+++ b/src/PlaneOfBlocks.cpp
@@ -733,7 +733,7 @@ static void pobCrossSearch(PlaneOfBlocks *pob, int start, int x_max, int y_max, 
     }
 
     for (int j = start; j < y_max; j += 2) {
-        pobCheckMV<dctmode, nLogPel>(pob, mvx, mvy + j);
+        pobCheckMV<dctmode, nLogPel>(pob, mvx, mvy - j);
         pobCheckMV<dctmode, nLogPel>(pob, mvx, mvy + j);
     }
 }


### PR DESCRIPTION
This is a *very* old bug, possibly back to the dawn of this plugin.

I originally found this in the Avisynth version, and I've been meaning to port the fix back here.

Ref: https://github.com/pinterf/mvtools/issues/56