### PR TITLE
Fix typo in Super

### DIFF
--- a/src/MVSuper.c
+++ b/src/MVSuper.c
@@ -227,7 +227,7 @@ static void VS_CC mvsuperCreate(const VSMap *in, VSMap *out, void *userData, VSC
     d.pelclip = vsapi->mapGetNode(in, "pelclip", 0, &err);
     const VSVideoInfo *pelvi = d.pelclip ? vsapi->getVideoInfo(d.pelclip) : NULL;
 
-    if (d.pelclip && (!vsh_isConstantVideoFormat(pelvi) || vsh_isSameVideoFormat(&pelvi->format, &d.vi.format))) {
+    if (d.pelclip && (!vsh_isConstantVideoFormat(pelvi) || !vsh_isSameVideoFormat(&pelvi->format, &d.vi.format))) {
         vsapi->mapSetError(out, "Super: pelclip must have the same format as the input clip, and it must have constant dimensions.");
         vsapi->freeNode(d.node);
         vsapi->freeNode(d.pelclip);


### PR DESCRIPTION
Unfortunately only one error.

Checked the entirety of this commit: <https://github.com/NSQY/vapoursynth-mvtools/commit/fd0c945fb8e71dcb46424636d6a274e498863252#diff-04d198744848e5b011f7c15c8d69aee1c409db17167bd05a988cc80891b3dfebR230>

PR just for convenience instead of opening an issue, I'll get if you close and commit yourself xd