### PR TITLE
Fix Compensate with overlap = 0.

### DIFF
--- a/src/CopyCode.cpp
+++ b/src/CopyCode.cpp
@@ -10,8 +10,6 @@ void copyBlock(uint8_t * __restrict pDst, intptr_t nDstPitch, const uint8_t * __
     int unroll = (height >= 8 ? 8 : (height >= 4 ? 4 : (height >= 2 ? 2 : 1))) / ((width + 15) / 16);
     unroll = unroll < 1 ? 1 : unroll;
 
-    nDstPitch = width;
-
     for (unsigned j = 0; j < height; j += unroll) {
         memcpy(pDst + 0 * nDstPitch, pSrc + 0 * nSrcPitch, width);
         if (unroll > 1) {


### PR DESCRIPTION
There was a bug introduced in a previous commit that broke Compensate with `overlap = 0`. Most scripts overwrite `overlap` to be a non-zero value, so the impact has been minimal in some ways.

The bug appeared to be introduced as part of optimizing SAD calculations, however the underlying behavior of overriding pitch based on the block width was unnecessary, as all calls from Analyze to the copy code always specified the same value for pitch and width.

But overriding pitch to block width is what broke Compensate, which uses very different pitch and block widths.

So as far as I can tell, the line I've deleted in this commit was just a straight up bug and held no part in the originally intended optimization.

I tested this by adding a conditional fprintf based on any difference between pitch and width and a difference only appeared in Compensate. Analyze was completely silent, meaning that pitch and width were always equal.

Fixes #54