### PR TITLE
Change flowfps frame count calculation

### DIFF
--- a/src/MVFlowFPS.c
+++ b/src/MVFlowFPS.c
@@ -754,7 +754,7 @@ static void VS_CC mvflowfpsCreate(const VSMap *in, VSMap *out, void *userData, V
 
     setFPS(&d.vi, numerator, denominator);
 
-    d.vi.numFrames = (int)(1 + (d.vi.numFrames - 1) * d.fb / d.fa);
+    d.vi.numFrames = (int)(d.vi.numFrames * d.fb / d.fa);
 
 
     if (d.mvbw_data.nWidth != d.vi.width || d.mvbw_data.nHeight != d.vi.height) {


### PR DESCRIPTION
The flowfps frame count calculation seems to have always been done with `- 1` before multiplying and `+ 1` after, but I don't understand what the rationale for this arithmetic could be, and seems wrong for simple integer multiples. Removing this subtraction and addition resolves the simple integer multiple cases and seems probably harmless for fractional cases.