### PR TITLE
Improve compiling for much better performance.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
             mingw-w64-x86_64-fftw
       - name: Build vs-mvtools
         run: |
-          meson setup build --buildtype release --prefer-static --default-library=static -Dcpp_link_args='-static'
+          meson setup build --buildtype release --prefer-static --default-library=static  -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dc_link_args='-static' -Dcpp_link_args='-static'
           meson compile -vC build
       - name: Export version
         run: |
@@ -72,7 +72,7 @@ jobs:
             mingw-w64-i686-fftw
       - name: Build vs-mvtools
         run: |
-          meson setup build --buildtype release --prefer-static --default-library=static -Dcpp_link_args='-static'
+          meson setup build --buildtype release --prefer-static --default-library=static -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dc_link_args='-static' -Dcpp_link_args='-static'
           meson compile -vC build
       - name: Export version
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,21 +58,21 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: CLANG32
+          msystem: MINGW32
           update: true
           install: >-
             base-devel
-            mingw-w64-clang-i686-jq
-            mingw-w64-clang-i686-clang
-            mingw-w64-clang-i686-pkg-config
-            mingw-w64-clang-i686-vapoursynth
-            mingw-w64-clang-i686-meson
-            mingw-w64-clang-i686-ninja
-            mingw-w64-clang-i686-nasm
-            mingw-w64-clang-i686-fftw
+            mingw-w64-i686-jq
+            mingw-w64-i686-gcc
+            mingw-w64-i686-pkg-config
+            mingw-w64-i686-vapoursynth
+            mingw-w64-i686-meson
+            mingw-w64-i686-ninja
+            mingw-w64-i686-nasm
+            mingw-w64-i686-fftw
       - name: Build vs-mvtools
         run: |
-          meson setup build --buildtype release --prefer-static --default-library=static -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dc_link_args='-static' -Dcpp_link_args='-static'
+          meson setup build --buildtype release --prefer-static --default-library=static -Dcpp_link_args='-static'
           meson compile -vC build
       - name: Export version
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4.3.3
         with:
-          name: mvtools-windows-x64-${{ env.ARTIFACT_VERSION }}
+          name: mvtools-windows-x64-znver2-${{ env.ARTIFACT_VERSION }}
           path: build/libmvtools.dll
   build-windows-x86:
     runs-on: windows-latest

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,6 +45,43 @@ jobs:
         with:
           name: mvtools-windows-x64-${{ env.ARTIFACT_VERSION }}
           path: build/libmvtools.dll
+  build-windows-x64-znver2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-clang-x86_64-jq
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-pkg-config
+            mingw-w64-clang-x86_64-vapoursynth
+            mingw-w64-clang-x86_64-meson
+            mingw-w64-clang-x86_64-ninja
+            mingw-w64-clang-x86_64-nasm
+            mingw-w64-clang-x86_64-fftw
+      - name: Build vs-mvtools
+        run: |
+          meson setup build --buildtype release --prefer-static --default-library=static -Dc_args='-march=znver2 -mtune=znver2 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dcpp_args='-march=znver2 -mtune=znver2 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dc_link_args='-static' -Dcpp_link_args='-static'
+          meson compile -vC build
+      - name: Export version
+        run: |
+          echo "ARTIFACT_VERSION=$(meson introspect --projectinfo build | jq -r '.version')" >> $GITHUB_ENV
+      - name: Upload
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: mvtools-windows-x64-${{ env.ARTIFACT_VERSION }}
+          path: build/libmvtools.dll
   build-windows-x86:
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,21 +21,21 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           update: true
           install: >-
             base-devel
-            mingw-w64-x86_64-jq
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-vapoursynth
-            mingw-w64-x86_64-meson
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-nasm
-            mingw-w64-x86_64-fftw
+            mingw-w64-clang-x86_64-jq
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-pkg-config
+            mingw-w64-clang-x86_64-vapoursynth
+            mingw-w64-clang-x86_64-meson
+            mingw-w64-clang-x86_64-ninja
+            mingw-w64-clang-x86_64-nasm
+            mingw-w64-clang-x86_64-fftw
       - name: Build vs-mvtools
         run: |
-          meson setup build --buildtype release --prefer-static --default-library=static  -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dc_link_args='-static' -Dcpp_link_args='-static'
+          meson setup build --buildtype release --prefer-static --default-library=static -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mprefer-vector-width=512' -Dc_link_args='-static' -Dcpp_link_args='-static'
           meson compile -vC build
       - name: Export version
         run: |
@@ -58,18 +58,18 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW32
+          msystem: CLANG32
           update: true
           install: >-
             base-devel
-            mingw-w64-i686-jq
-            mingw-w64-i686-gcc
-            mingw-w64-i686-pkg-config
-            mingw-w64-i686-vapoursynth
-            mingw-w64-i686-meson
-            mingw-w64-i686-ninja
-            mingw-w64-i686-nasm
-            mingw-w64-i686-fftw
+            mingw-w64-clang-i686-jq
+            mingw-w64-clang-i686-clang
+            mingw-w64-clang-i686-pkg-config
+            mingw-w64-clang-i686-vapoursynth
+            mingw-w64-clang-i686-meson
+            mingw-w64-clang-i686-ninja
+            mingw-w64-clang-i686-nasm
+            mingw-w64-clang-i686-fftw
       - name: Build vs-mvtools
         run: |
           meson setup build --buildtype release --prefer-static --default-library=static -Dc_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dcpp_args='-march=x86-64-v3 -mtune=x86-64 -flto -fwhole-program-vtables -mno-gather' -Dc_link_args='-static' -Dcpp_link_args='-static'


### PR DESCRIPTION
The new CI builds in this PR significantly improve performance.  

Test clip 1 with little grain:
[Original CI build](https://github.com/Akatmks/vapoursynth-mvtools-pr/actions/runs/17664000417/job/50202404561#step:6:22): `Output 1000 frames in 42.88 seconds (23.32 fps)`
→ [New CI build](https://github.com/Akatmks/vapoursynth-mvtools-pr/actions/runs/17664592612/job/50203969368#step:6:22): `Output 1000 frames in 35.79 seconds (27.94 fps)` (+20%)
→ [New `znver2` CI build](https://github.com/Akatmks/vapoursynth-mvtools-pr/actions/runs/17664592612/job/50203969371#step:6:22): `Output 1000 frames in 35.57 seconds (28.11 fps)` (+21%)

Test clip 2 with a lot of grain:
Original CI build: `Output 1000 frames in 62.01 seconds (16.13 fps)`
→ New CI build: `Output 1000 frames in 47.81 seconds (20.92 fps)` (+30%)
→ New `znver2` CI build: `Output 1000 frames in 47.46 seconds (21.07 fps)` (+31%)

The `znver2` version is the fastest on all CPU, even including Intel ones. However, it may fail to run on some older Intel CPU. The generic `x86-64-v3` build should be the preferred binary for `vsrepo.py` and other automated installs, while people can manually download `znver2` build for better performance.

Also, it would probably be a good idea to backport this new CI build method to the last release version and update the binary in [GitHub Release](https://github.com/dubhater/vapoursynth-mvtools/releases).

## Details

This is the improvement from each optimisations:

Test clip 1 with little grain:
Original build with gcc: `23.39 fps`
→ New build with clang: `25.00 fps` (+7%)
→ New build with clang for `x86-64-v3`: `28.14 fps` (+20%)
→ New build with clang for `znver2`: `28.25 fps` (+21%)
→ New build with clang for `znver2` with (probably not the best) PGO: `28.82 fps` (+23%)

Test clip 2 with a lot of grain:
Original build with gcc: `16.12 fps`
→ New build with clang: `17.80 fps` (+10%)
→ New build with clang for `x86-64-v3`: `20.86 fps` (+29%)
→ New build with clang for `znver2`: `21.06 fps` (+31%)
→ New build with clang for `znver2` with (probably not the best) PGO: `21.39 fps` (+33%)

The PR contains the third and fourth build here.

Although the fifth build with PGO can provide additional 2% speed improvements, PGO requires running with real video clips, which may not be very easy to implement in CI.
That's said, it's possible for me to build it manually for releases. Tell me if you think that's a good idea.

I heard that people are considering switching to vectorclass in the future. With that we might be able to compile using clang-cl, which will bring additional improvements. This PR is probably around the best we can do as of right now.

Thanks!